### PR TITLE
Adapt fix from forum post

### DIFF
--- a/src/PdfSharper/Pdf/PdfReferenceTable.cs
+++ b/src/PdfSharper/Pdf/PdfReferenceTable.cs
@@ -266,8 +266,11 @@ namespace PdfSharper.Pdf
             ObjectTable.Clear();
             foreach (PdfReference iref in irefs)
             {
-                ObjectTable.Add(iref.ObjectID, iref);
-                _maxObjectNumber = Math.Max(_maxObjectNumber, iref.ObjectNumber);
+                if(!ObjectTable.ContainsKey(iref.ObjectID))
+                {
+                    ObjectTable.Add(iref.ObjectID, iref);
+                    _maxObjectNumber = Math.Max(_maxObjectNumber, iref.ObjectNumber);
+                }
             }
             //CheckConsistence();
             removed -= ObjectTable.Count;


### PR DESCRIPTION
http://forum.pdfsharp.net/viewtopic.php?f=3&t=2827

Fixes 'An item with the same key has already been added.' being thrown in RenderDocument of MigraDoc