### PR TITLE
Text field sets a DA stream based on the applied font and forecolor

### DIFF
--- a/src/PdfSharper/Drawing/XColors.cs
+++ b/src/PdfSharper/Drawing/XColors.cs
@@ -64,7 +64,7 @@ namespace PdfSharper.Drawing
         public static XColor Bisque { get { return new XColor(XKnownColor.Bisque); } }
 
         ///<summary>Gets a predefined color.</summary>
-        public static XColor Black { get { return new XColor(XKnownColor.Black); } }
+        public static XColor Black { get { return XColor.FromGrayScale(0d); } }
 
         ///<summary>Gets a predefined color.</summary>
         public static XColor BlanchedAlmond { get { return new XColor(XKnownColor.BlanchedAlmond); } }
@@ -115,7 +115,7 @@ namespace PdfSharper.Drawing
         public static XColor DarkGoldenrod { get { return new XColor(XKnownColor.DarkGoldenrod); } }
 
         ///<summary>Gets a predefined color.</summary>
-        public static XColor DarkGray { get { return new XColor(XKnownColor.DarkGray); } }
+        public static XColor DarkGray { get { return XColor.FromGrayScale(0.66d); } }
 
         ///<summary>Gets a predefined color.</summary>
         public static XColor DarkGreen { get { return new XColor(XKnownColor.DarkGreen); } }
@@ -163,7 +163,7 @@ namespace PdfSharper.Drawing
         public static XColor DeepSkyBlue { get { return new XColor(XKnownColor.DeepSkyBlue); } }
 
         ///<summary>Gets a predefined color.</summary>
-        public static XColor DimGray { get { return new XColor(XKnownColor.DimGray); } }
+        public static XColor DimGray { get { return XColor.FromGrayScale(0.43d); } }
 
         ///<summary>Gets a predefined color.</summary>
         public static XColor DodgerBlue { get { return new XColor(XKnownColor.DodgerBlue); } }
@@ -193,7 +193,7 @@ namespace PdfSharper.Drawing
         public static XColor Goldenrod { get { return new XColor(XKnownColor.Goldenrod); } }
 
         ///<summary>Gets a predefined color.</summary>
-        public static XColor Gray { get { return new XColor(XKnownColor.Gray); } }
+        public static XColor Gray { get { return XColor.FromGrayScale(0.5d); } }
 
         ///<summary>Gets a predefined color.</summary>
         public static XColor Green { get { return new XColor(XKnownColor.Green); } }
@@ -244,7 +244,7 @@ namespace PdfSharper.Drawing
         public static XColor LightGoldenrodYellow { get { return new XColor(XKnownColor.LightGoldenrodYellow); } }
 
         ///<summary>Gets a predefined color.</summary>
-        public static XColor LightGray { get { return new XColor(XKnownColor.LightGray); } }
+        public static XColor LightGray { get { return XColor.FromGrayScale(0.88d); } }
 
         ///<summary>Gets a predefined color.</summary>
         public static XColor LightGreen { get { return new XColor(XKnownColor.LightGreen); } }
@@ -454,7 +454,7 @@ namespace PdfSharper.Drawing
         public static XColor Wheat { get { return new XColor(XKnownColor.Wheat); } }
 
         ///<summary>Gets a predefined color.</summary>
-        public static XColor White { get { return new XColor(XKnownColor.White); } }
+        public static XColor White { get { return XColor.FromGrayScale(1d); } }
 
         ///<summary>Gets a predefined color.</summary>
         public static XColor WhiteSmoke { get { return new XColor(XKnownColor.WhiteSmoke); } }

--- a/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
@@ -391,6 +391,24 @@ namespace PdfSharper.Pdf.AcroForms
         internal override void PrepareForSave()
         {
             base.PrepareForSave();
+
+            //set or update the default appearance stream
+            string textAppearanceStream = string.Format("/{0} {1:0.##} Tf", Font.FamilyName, Font.Size);
+
+            string colorStream = string.Empty;
+
+            switch (ForeColor.ColorSpace)
+            {
+                case XColorSpace.Rgb:
+                    colorStream = string.Format("{0:0.#} {1:0.#} {2:0.#} rg", ForeColor.R / 255d, ForeColor.G / 255d, ForeColor.B / 255);
+                    break;
+                case XColorSpace.GrayScale:
+                    colorStream = string.Format("{0:0.#} g", ForeColor.GS);
+                    break;
+            }
+
+            Elements.SetString(Keys.DA, textAppearanceStream + " " + colorStream);
+
             RenderAppearance();
         }
 


### PR DESCRIPTION
Apply font changes to the default appearance stream, any form elements that get rendered by adobe reader require this stream to be present in form fields.

Prerequisite work for adding a text field.