### PR TITLE
XForm needs to render the stream even when not gdi!

### DIFF
--- a/src/PdfSharper/Drawing/XForm.cs
+++ b/src/PdfSharper/Drawing/XForm.cs
@@ -230,13 +230,13 @@ namespace PdfSharper.Drawing
         /// </summary>
         internal virtual void Finish()
         {
-#if GDI
+
             if (_formState == FormState.NotATemplate || _formState == FormState.Finished)
                 return;
-
+#if GDI
             if (Gfx.Metafile != null)
                 _gdiImage = Gfx.Metafile;
-
+#endif
             Debug.Assert(_formState == FormState.Created || _formState == FormState.UnderConstruction);
             _formState = FormState.Finished;
             Gfx.Dispose();
@@ -256,9 +256,6 @@ namespace PdfSharper.Drawing
                 int length = _pdfForm.Stream.Length;
                 _pdfForm.Elements.SetInteger("/Length", length);
             }
-#endif
-#if WPF
-#endif
         }
 
         /// <summary>


### PR DESCRIPTION
Form streams need to be generated all the time or the "Hack" to generate an AP stream in pdftextfield will never work, it throws null reference or does not put the text into the stream.