### PR TITLE
PrepareForSave() now called on all Fields

### DIFF
--- a/src/PdfSharper/Pdf.AcroForms/PdfAcroForm.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfAcroForm.cs
@@ -27,6 +27,9 @@
 // DEALINGS IN THE SOFTWARE.
 #endregion
 
+using System.Collections.Generic;
+using System.Linq;
+
 namespace PdfSharper.Pdf.AcroForms
 {
     /// <summary>
@@ -76,6 +79,38 @@ namespace PdfSharper.Pdf.AcroForms
                 field.Flatten();
             }
             _document.Catalog.AcroForm = null;
+        }
+
+        internal override void PrepareForSave()
+        {
+            base.PrepareForSave();
+
+            IEnumerable<PdfAcroField> typedFields = Fields;
+
+            var allFields = typedFields.Concat(typedFields.SelectMany(tf => WalkAllFields(tf)));
+            foreach (var element in allFields)
+            {
+                element.PrepareForSave();
+            }
+        }
+
+        public IEnumerable<PdfAcroField> WalkAllFields(PdfAcroField current)
+        {
+            if (!current.HasKids)
+            {
+                yield return current;
+                yield break;
+            }
+
+
+            foreach (var child in current.Fields)
+            {
+                var subchildren = WalkAllFields(child);
+                foreach (var subChild in subchildren)
+                {
+                    yield return subChild;
+                }
+            }
         }
 
         /// <summary>

--- a/src/PdfSharper/Pdf.AcroForms/PdfSignatureField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfSignatureField.cs
@@ -129,7 +129,7 @@ namespace PdfSharper.Pdf.AcroForms
                 return;
 
             if (this.AppearanceHandler == null)
-                throw new Exception("AppearanceHandler is null");
+                return;
 
 
 

--- a/src/PdfSharper/Pdf.Advanced/PdfCatalog.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfCatalog.cs
@@ -208,6 +208,11 @@ namespace PdfSharper.Pdf.Advanced
             if (_pages != null)
                 _pages.PrepareForSave();
 
+            if (AcroForm != null)
+            {
+                AcroForm.PrepareForSave();
+            }
+
             if (_outline != null && _outline.Outlines.Count > 0)
             {
                 if (Elements[Keys.PageMode] == null)


### PR DESCRIPTION
Now when a document is being prepared for save the AcroForm will call PrepareForSave() on all of its child Fields. These weren't being called under any circumstance previously...