### PR TITLE
Making the createacrofieldmethod visible

### DIFF
--- a/src/PdfSharper/Pdf.AcroForms/PdfAcroField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfAcroField.cs
@@ -887,7 +887,7 @@ namespace PdfSharper.Pdf.AcroForms
             /// If the actual cannot be guessed by PDFsharp the function returns an instance
             /// of PdfGenericField.
             /// </summary>
-            internal static PdfAcroField CreateAcroField(PdfDictionary dict)
+            public static PdfAcroField CreateAcroField(PdfDictionary dict)
             {
                 switch (PdfAcroField.DetermineFieldType(dict))
                 {

--- a/src/PdfSharper/Pdf.AcroForms/PdfGenericField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfGenericField.cs
@@ -40,7 +40,7 @@ namespace PdfSharper.Pdf.AcroForms
         /// <summary>
         /// Initializes a new instance of PdfGenericField.
         /// </summary>
-        internal PdfGenericField(PdfDocument document)
+        public PdfGenericField(PdfDocument document)
             : base(document)
         { }
 

--- a/src/PdfSharper/Pdf/PdfPage.cs
+++ b/src/PdfSharper/Pdf/PdfPage.cs
@@ -731,7 +731,7 @@ namespace PdfSharper.Pdf
         /// <summary>
         /// Predefined keys of this dictionary.
         /// </summary>
-        internal sealed class Keys : InheritablePageKeys
+        public sealed class Keys : InheritablePageKeys
         {
             /// <summary>
             /// (Required) The type of PDF object that this dictionary describes;
@@ -951,7 +951,7 @@ namespace PdfSharper.Pdf
         /// <summary>
         /// Predefined keys common to PdfPage and PdfPages.
         /// </summary>
-        internal class InheritablePageKeys : KeysBase
+        public class InheritablePageKeys : KeysBase
         {
             /// <summary>
             /// (Required; inheritable) A dictionary containing any resources required by the page. 

--- a/src/PdfSharper/Pdf/PdfPages.cs
+++ b/src/PdfSharper/Pdf/PdfPages.cs
@@ -454,7 +454,7 @@ namespace PdfSharper.Pdf
         /// <summary>
         /// Helper function for ImportExternalPage.
         /// </summary>
-        void CloneElement(PdfPage page, PdfPage importPage, string key, bool deepcopy)
+        public void CloneElement(PdfPage page, PdfPage importPage, string key, bool deepcopy)
         {
             Debug.Assert(page != null);
             Debug.Assert(page.Owner == _document);


### PR DESCRIPTION
Ability to construct generic fields for form field trees
Page keys and CloneElement made visible to be used for a simple copy page