### PR TITLE
Template pdfs retain non-embedded system fonts

### DIFF
--- a/src/PdfSharper/!internal/Configuration.cs
+++ b/src/PdfSharper/!internal/Configuration.cs
@@ -60,7 +60,7 @@ namespace PdfSharper
         /// Factor of the em size of a regular font to look bold. Used for bold simulation.
         /// Value of 2% found in original XPS 1.0 documentation.
         /// </summary>
-        public const double BoldEmphasis = 0.02;
+        public const double BoldEmphasis = 0.0273;//0.0412;
 
         // The κ (kappa) for drawing a circle or an ellipse with four Bézier splines, specifying the distance of the influence point from the starting or end point of a spline.
         // Petzold: 4/3 * tan(α / 4)

--- a/src/PdfSharper/Drawing.Pdf/XGraphicsPdfRenderer.cs
+++ b/src/PdfSharper/Drawing.Pdf/XGraphicsPdfRenderer.cs
@@ -510,11 +510,12 @@ namespace PdfSharper.Drawing.Pdf
             realizedFont.AddChars(s);
 
             const string format2 = Config.SignificantFigures4;
-            OpenTypeDescriptor descriptor = realizedFont.FontDescriptor._descriptor;
+
 
             string text = null;
             if (font.Unicode)
             {
+                OpenTypeDescriptor descriptor = realizedFont.FontDescriptor._descriptor;
                 StringBuilder sb = new StringBuilder();
                 bool isSymbolFont = descriptor.FontFace.cmap.symbol;
                 for (int idx = 0; idx < s.Length; idx++)

--- a/src/PdfSharper/Drawing.Pdf/XGraphicsPdfRenderer.cs
+++ b/src/PdfSharper/Drawing.Pdf/XGraphicsPdfRenderer.cs
@@ -456,7 +456,7 @@ namespace PdfSharper.Drawing.Pdf
                         break;
 
                     case XStringAlignment.Far:
-                        x += rect.Width - width;
+                        x += rect.Width - (width + x);
                         break;
                 }
             }
@@ -470,7 +470,8 @@ namespace PdfSharper.Drawing.Pdf
 
                     case XLineAlignment.Center:
                         // TODO: Use CapHeight. PDFlib also uses 3/4 of ascent
-                        y += (cyAscent * 3 / 4) / 2 + rect.Height / 2;
+                        //Insane magic number we calculated from HELV bold, its a starting point?
+                        y += (cyAscent * 0.8416421845574388) / 2 + rect.Height / 2;
                         break;
 
                     case XLineAlignment.Far:
@@ -1849,7 +1850,7 @@ namespace PdfSharper.Drawing.Pdf
         void Realize(XFont font, XBrush brush, int renderingMode)
         {
             BeginPage();
-            RealizeTransform();
+            //RealizeTransform();
             BeginTextMode();
             _gfxState.RealizeFont(font, brush, renderingMode);
         }

--- a/src/PdfSharper/Drawing/FontHelper.cs
+++ b/src/PdfSharper/Drawing/FontHelper.cs
@@ -101,7 +101,8 @@ namespace PdfSharper.Drawing
                 size.Width = width * font.Size / descriptor.UnitsPerEm;
 
                 // Adjust bold simulation.
-                if ((font.GlyphTypeface.StyleSimulations & XStyleSimulations.BoldSimulation) == XStyleSimulations.BoldSimulation)
+                if ((font.GlyphTypeface.StyleSimulations & XStyleSimulations.BoldSimulation) == XStyleSimulations.BoldSimulation ||
+                    DoApplyBoldHack(font.FamilyName)) //BOLD hacks for helvetica
                 {
                     // Add 2% of the em-size for each character.
                     // Unsure how to deal with white space. Currently count as regular character.
@@ -110,6 +111,18 @@ namespace PdfSharper.Drawing
             }
             Debug.Assert(descriptor != null, "No OpenTypeDescriptor.");
             return size;
+        }
+
+        private static bool DoApplyBoldHack(string familyName)
+        {
+            //TODO: remove when we parse afm files from adobe
+            switch (familyName)
+            {
+                case "Helvetica-Bold":
+                    return true;
+                default:
+                    return false; ;
+            }
         }
 
 #if CORE || GDI

--- a/src/PdfSharper/Drawing/XForm.cs
+++ b/src/PdfSharper/Drawing/XForm.cs
@@ -448,6 +448,7 @@ namespace PdfSharper.Drawing
             else
             {
                 pdfFont = GetFontFromResources(font);
+                Debug.Assert(pdfFont != null);
             }
             return name;
         }

--- a/src/PdfSharper/Drawing/XForm.cs
+++ b/src/PdfSharper/Drawing/XForm.cs
@@ -494,7 +494,7 @@ namespace PdfSharper.Drawing
             return null;
         }
 
-        private static KeyValuePair<string, PdfItem> GetFontResourceItem(string familyName, PdfDictionary defaultFormResources)
+        internal static KeyValuePair<string, PdfItem> GetFontResourceItem(string familyName, PdfDictionary defaultFormResources)
         {
             var fontList = defaultFormResources.Elements.GetDictionary(PdfResources.Keys.Font);
 

--- a/src/PdfSharper/Drawing/XForm.cs
+++ b/src/PdfSharper/Drawing/XForm.cs
@@ -42,6 +42,11 @@ using PdfSharper.Drawing.Pdf;
 using PdfSharper.Pdf;
 using PdfSharper.Pdf.Advanced;
 using PdfSharper.Pdf.Filters;
+using PdfSharper.Pdf.AcroForms;
+using System.Linq;
+using PdfSharper.Fonts.OpenType;
+using PdfSharper.Fonts;
+using System.Collections.Generic;
 
 namespace PdfSharper.Drawing
 {
@@ -432,11 +437,73 @@ namespace PdfSharper.Drawing
         internal string GetFontName(XFont font, out PdfFont pdfFont)
         {
             Debug.Assert(IsTemplate, "This function is for form templates only.");
-            pdfFont = _document.FontTable.GetFont(font);
-            Debug.Assert(pdfFont != null);
-            string name = Resources.AddFont(pdfFont);
+            string name = GetFontNameFromResources(font.FamilyName, font.Bold, font.Italic);
+
+            if (string.IsNullOrEmpty(name)) //sure go ahead and try your broken embedding
+            {
+                pdfFont = _document.FontTable.GetFont(font);
+                Debug.Assert(pdfFont != null);
+                name = Resources.AddFont(pdfFont);
+            }
+            else
+            {
+                pdfFont = GetFontFromResources(font);
+            }
             return name;
         }
+        private string GetFontNameFromResources(string familyName, bool isBold, bool isItalic)
+        {
+            //TODO: Check that bold an italic are found through just their font names
+            var defaultFormResources = Owner.AcroForm.Elements.GetDictionary(PdfAcroForm.Keys.DR);
+            if (defaultFormResources != null && defaultFormResources.Elements.ContainsKey(PdfResources.Keys.Font))
+            {
+                return GetFontResourceItem(familyName, defaultFormResources).Key;
+            }
+
+            return string.Empty;
+        }
+
+        private PdfFont GetFontFromResources(XFont xFont)
+        {
+            //TODO: Check that bold an italic are found through just their font names
+            var defaultFormResources = Owner.AcroForm.Elements.GetDictionary(PdfAcroForm.Keys.DR);
+            if (defaultFormResources != null && defaultFormResources.Elements.ContainsKey(PdfResources.Keys.Font))
+            {
+                var fontList = defaultFormResources.Elements.GetDictionary(PdfResources.Keys.Font);
+
+                var font = GetFontResourceItem(xFont.FamilyName, defaultFormResources);
+
+                PdfItem value = font.Value;
+
+                if (value is PdfReference)
+                {
+                    value = ((PdfReference)value).Value;
+                }
+
+                PdfFont systemFont = new PdfFont(value as PdfDictionary);
+                if (systemFont.FontEncoding == PdfFontEncoding.Unicode)
+                {
+                    OpenTypeDescriptor ttDescriptor = (OpenTypeDescriptor)FontDescriptorCache.GetOrCreateDescriptorFor(xFont);
+                    systemFont.FontDescriptor = new PdfFontDescriptor(Owner, ttDescriptor);
+                }
+
+                return systemFont;
+            }
+
+            return null;
+        }
+
+        private static KeyValuePair<string, PdfItem> GetFontResourceItem(string familyName, PdfDictionary defaultFormResources)
+        {
+            var fontList = defaultFormResources.Elements.GetDictionary(PdfResources.Keys.Font);
+
+            var font = fontList.Elements.FirstOrDefault(e => e.Key == familyName ||
+                                                        fontList.Elements.GetDictionary(e.Key).Elements.GetName(PdfFont.Keys.BaseFont) ==
+                                                        "/" + familyName);
+            return font;
+        }
+
+
 
         string IContentStream.GetFontName(XFont font, out PdfFont pdfFont)
         {

--- a/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
@@ -406,18 +406,18 @@ namespace PdfSharper.Pdf.AcroForms
 
             var normalStateDict = ap.Elements.GetDictionary("/N");
             var resourceDict = new PdfDictionary(Owner);
-            resourceDict.Elements["/ProcSet"] = new PdfArray(Owner, new PdfName("/PDF"), new PdfName("/Text"));
+            resourceDict.Elements[PdfResources.Keys.ProcSet] = new PdfArray(Owner, new PdfName("/PDF"), new PdfName("/Text"));
 
             var defaultFormResources = Owner.AcroForm.Elements.GetDictionary(PdfAcroForm.Keys.DR);
             if (defaultFormResources != null && defaultFormResources.Elements.ContainsKey(PdfResources.Keys.Font))
             {
                 var fontResourceItem = XForm.GetFontResourceItem(Font.FamilyName, defaultFormResources);
                 PdfDictionary fontDict = new PdfDictionary(Owner);
-                resourceDict.Elements["/Font"] = fontDict;
+                resourceDict.Elements[PdfResources.Keys.Font] = fontDict;
                 fontDict.Elements[fontResourceItem.Key] = fontResourceItem.Value;
             }
 
-            normalStateDict.Elements.SetObject("/Resources", resourceDict);
+            normalStateDict.Elements.SetObject(PdfPage.Keys.Resources, resourceDict);
 
             PdfFormXObject xobj = form.PdfForm;
             if (xobj.Stream == null)

--- a/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
@@ -383,8 +383,10 @@ namespace PdfSharper.Pdf.AcroForms
                 }
                 else
                 {
-                    gfx.DrawString(Text, Font, new XSolidBrush(ForeColor),
-                      rect.ToXRect() - rect.Location + new XPoint(2, 0), Alignment);
+                    XTextFormatter formatter = new XTextFormatter(gfx);
+                    formatter.Text = text;
+
+                    formatter.DrawString(text, Font, new XSolidBrush(ForeColor), rect.ToXRect() - rect.Location, Alignment);
                 }
             }
 
@@ -400,7 +402,22 @@ namespace PdfSharper.Pdf.AcroForms
             }
 
             // Set XRef to normal state
-            ap.Elements["/N"] = form.PdfForm.Reference;
+            ap.Elements["/N"] = PdfObject.DeepCopyClosure(Owner, form.PdfForm);
+
+            var normalStateDict = ap.Elements.GetDictionary("/N");
+            var resourceDict = new PdfDictionary(Owner);
+            resourceDict.Elements["/ProcSet"] = new PdfArray(Owner, new PdfName("/PDF"), new PdfName("/Text"));
+
+            var defaultFormResources = Owner.AcroForm.Elements.GetDictionary(PdfAcroForm.Keys.DR);
+            if (defaultFormResources != null && defaultFormResources.Elements.ContainsKey(PdfResources.Keys.Font))
+            {
+                var fontResourceItem = XForm.GetFontResourceItem(Font.FamilyName, defaultFormResources);
+                PdfDictionary fontDict = new PdfDictionary(Owner);
+                resourceDict.Elements["/Font"] = fontDict;
+                fontDict.Elements[fontResourceItem.Key] = fontResourceItem.Value;
+            }
+
+            normalStateDict.Elements.SetObject("/Resources", resourceDict);
 
             PdfFormXObject xobj = form.PdfForm;
             if (xobj.Stream == null)
@@ -410,7 +427,7 @@ namespace PdfSharper.Pdf.AcroForms
             // Thank you Adobe: Without putting the content in 'EMC brackets'
             // the text is not rendered by PDF Reader 9 or higher.
             s = "/Tx BMC\n" + s + "\nEMC";
-            xobj.Stream.Value = new RawEncoding().GetBytes(s);
+            ap.Elements.GetDictionary("/N").Stream.Value = new RawEncoding().GetBytes(s);
 #endif
         }
 

--- a/src/PdfSharper/Pdf.Advanced/PdfFont.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfFont.cs
@@ -46,6 +46,10 @@ namespace PdfSharper.Pdf.Advanced
             : base(document)
         { }
 
+        public PdfFont(PdfDictionary dict)
+            : base(dict)
+        { }
+
         internal PdfFontDescriptor FontDescriptor
         {
             get

--- a/src/PdfSharper/Pdf.Internal/PdfEncoders.cs
+++ b/src/PdfSharper/Pdf.Internal/PdfEncoders.cs
@@ -410,7 +410,7 @@ namespace PdfSharper.Pdf.Internal
             }
             else
             {
-            Hex:
+                Hex:
                 if (hex)
                 {
                     pdf.Append(prefix ? "<FEFF" : "<");
@@ -603,7 +603,13 @@ namespace PdfSharper.Pdf.Internal
 
             // If not defined let color decide
             if (colorMode == PdfColorMode.Undefined)
+            {
+                if (color.ColorSpace == XColorSpace.GrayScale)
+                {
+                    return string.Format(CultureInfo.InvariantCulture, "{0:" + format + "}", color.GS);
+                }
                 colorMode = color.ColorSpace == XColorSpace.Cmyk ? PdfColorMode.Cmyk : PdfColorMode.Rgb;
+            }
 
             switch (colorMode)
             {

--- a/src/PdfSharper/Pdf/PdfPages.cs
+++ b/src/PdfSharper/Pdf/PdfPages.cs
@@ -454,7 +454,7 @@ namespace PdfSharper.Pdf
         /// <summary>
         /// Helper function for ImportExternalPage.
         /// </summary>
-        void CloneElement(PdfPage page, PdfPage importPage, string key, bool deepcopy)
+        internal void CloneElement(PdfPage page, PdfPage importPage, string key, bool deepcopy)
         {
             Debug.Assert(page != null);
             Debug.Assert(page.Owner == _document);


### PR DESCRIPTION
Must set GlobalFontSettings.Encoding to WinAsci to enable this feature.

Moving font descriptor to unicode section
XForm searches document acrofield resources for a matching font
PdfFont is constructable from a dictionary now