### PR TITLE
Feature/template field background and font null fix

### DIFF
--- a/src/PDFsharper.UnitTests/PdfTextFieldTests.cs
+++ b/src/PDFsharper.UnitTests/PdfTextFieldTests.cs
@@ -53,7 +53,7 @@ namespace PDFsharper.UnitTests
 
             tf.PrepareForSave();
 
-            Assert.IsFalse(tf.Elements.ContainsKey(PdfAnnotation.Keys.AP), "Empty Text Field should NOT have an appearance stream.");
+            Assert.IsTrue(tf.Elements.ContainsKey(PdfAnnotation.Keys.AP), "Empty Text Field should have an appearance stream, used for background colors.");
         }
     }
 }

--- a/src/PdfSharper/Pdf.AcroForms/PdfCheckBoxField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfCheckBoxField.cs
@@ -410,7 +410,7 @@ namespace PdfSharper.Pdf.AcroForms
             /// <summary>
             /// Gets the KeysMeta for these keys.
             /// </summary>
-            internal static DictionaryMeta Meta
+            internal static new DictionaryMeta Meta
             {
                 get { return _meta ?? (_meta = CreateMeta(typeof(Keys))); }
             }

--- a/src/PdfSharper/Pdf.AcroForms/PdfChoiceField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfChoiceField.cs
@@ -301,7 +301,7 @@ namespace PdfSharper.Pdf.AcroForms
             /// <summary>
             /// Gets the KeysMeta for these keys.
             /// </summary>
-            internal static DictionaryMeta Meta
+            internal static new DictionaryMeta Meta
             {
                 get { return _meta ?? (_meta = CreateMeta(typeof(Keys))); }
             }

--- a/src/PdfSharper/Pdf.AcroForms/PdfComboBoxField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfComboBoxField.cs
@@ -141,7 +141,7 @@ namespace PdfSharper.Pdf.AcroForms
         {
             // Combo boxes have no additional entries.
 
-            internal static DictionaryMeta Meta
+            internal static new DictionaryMeta Meta
             {
                 get
                 {

--- a/src/PdfSharper/Pdf.AcroForms/PdfGenericField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfGenericField.cs
@@ -65,7 +65,7 @@ namespace PdfSharper.Pdf.AcroForms
         /// </summary>
         public new class Keys : PdfAcroField.Keys
         {
-            internal static DictionaryMeta Meta
+            internal static new DictionaryMeta Meta
             {
                 get { return _meta ?? (_meta = CreateMeta(typeof(Keys))); }
             }

--- a/src/PdfSharper/Pdf.AcroForms/PdfListBoxField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfListBoxField.cs
@@ -210,7 +210,7 @@ namespace PdfSharper.Pdf.AcroForms
         {
             // List boxes have no additional entries.
 
-            internal static DictionaryMeta Meta
+            internal static new DictionaryMeta Meta
             {
                 get { return _meta ?? (_meta = CreateMeta(typeof(Keys))); }
             }

--- a/src/PdfSharper/Pdf.AcroForms/PdfPushButtonField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfPushButtonField.cs
@@ -79,7 +79,7 @@ namespace PdfSharper.Pdf.AcroForms
         /// </summary>
         public new class Keys : PdfAcroField.Keys
         {
-            internal static DictionaryMeta Meta
+            internal static  new DictionaryMeta Meta
             {
                 get { return _meta ?? (_meta = CreateMeta(typeof(Keys))); }
             }

--- a/src/PdfSharper/Pdf.AcroForms/PdfRadioButtonField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfRadioButtonField.cs
@@ -160,7 +160,7 @@ namespace PdfSharper.Pdf.AcroForms
             /// <summary>
             /// Gets the KeysMeta for these keys.
             /// </summary>
-            internal static DictionaryMeta Meta
+            internal static new DictionaryMeta Meta
             {
                 get { return _meta ?? (_meta = CreateMeta(typeof(Keys))); }
             }

--- a/src/PdfSharper/Pdf.AcroForms/PdfSignatureField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfSignatureField.cs
@@ -63,7 +63,7 @@ namespace PdfSharper.Pdf.AcroForms
             }
         }
 
-        public PdfItem Contents
+        public new PdfItem Contents
         {
             get
             {
@@ -187,7 +187,7 @@ namespace PdfSharper.Pdf.AcroForms
             /// (Required) The encrypted signature token.
             /// </summary>
             [KeyInfo(KeyType.String | KeyType.Required)]
-            public const string Contents = "/Contents";
+            public new const string Contents = "/Contents";
 
             /// <summary>
             /// (Optional) The name of the person or authority signing the document.
@@ -201,7 +201,7 @@ namespace PdfSharper.Pdf.AcroForms
             /// way from a secure time server.
             /// </summary>
             [KeyInfo(KeyType.Date | KeyType.Optional)]
-            public const string M = "/M";
+            public new const string M = "/M";
 
             /// <summary>
             /// (Optional) The CPU host name or physical location of the signing.
@@ -224,7 +224,7 @@ namespace PdfSharper.Pdf.AcroForms
             /// <summary>
             /// Gets the KeysMeta for these keys.
             /// </summary>
-            internal static DictionaryMeta Meta
+            internal static new DictionaryMeta Meta
             {
                 get { return _meta ?? (_meta = CreateMeta(typeof(Keys))); }
             }

--- a/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
@@ -69,7 +69,11 @@ namespace PdfSharper.Pdf.AcroForms
         public string Text
         {
             get { return Elements.GetString(Keys.V); }
-            set { Elements.SetString(Keys.V, value); RenderAppearance(); } //HACK in PdfTextField
+            set
+            {
+                Elements.SetString(Keys.V, value);
+                _needsAppearances = true;
+            }
         }
 
 
@@ -178,7 +182,7 @@ namespace PdfSharper.Pdf.AcroForms
         /// </summary>
         public bool MultiLine
         {
-            get { return (Flags & PdfAcroFieldFlags.Multiline) != 0; }
+            get { return (FieldFlags & PdfAcroFieldFlags.Multiline) != 0; }
             set
             {
                 if (value)
@@ -193,7 +197,7 @@ namespace PdfSharper.Pdf.AcroForms
         /// </summary>
         public bool Password
         {
-            get { return (Flags & PdfAcroFieldFlags.Password) != 0; }
+            get { return (FieldFlags & PdfAcroFieldFlags.Password) != 0; }
             set
             {
                 if (value)
@@ -209,7 +213,7 @@ namespace PdfSharper.Pdf.AcroForms
         /// </summary>
         public bool Combined
         {
-            get { return (Flags & PdfAcroFieldFlags.Comb) != 0; }
+            get { return (FieldFlags & PdfAcroFieldFlags.Comb) != 0; }
             set
             {
                 if (value)
@@ -219,17 +223,11 @@ namespace PdfSharper.Pdf.AcroForms
             }
         }
 
-        protected override void FontChanged()
-        {
-            RenderAppearance();
-        }
-
-
         /// <summary>
         /// Creates the normal appearance form X object for the annotation that represents
         /// this acro form text field.
         /// </summary>
-        void RenderAppearance()
+        protected override void RenderAppearance()
         {
 #if true_
             PdfFormXObject xobj = new PdfFormXObject(Owner);
@@ -351,7 +349,7 @@ namespace PdfSharper.Pdf.AcroForms
                 xrect.Width = xrect.Width + RightMargin;
                 xrect.Height = xrect.Height + BottomMargin;
 
-                if ((Flags & PdfAcroFieldFlags.Comb) != 0 && MaxLength > 0)
+                if ((FieldFlags & PdfAcroFieldFlags.Comb) != 0 && MaxLength > 0)
                 {
                     var combWidth = xrect.Width / MaxLength;
                     var format = XStringFormats.TopLeft;
@@ -458,7 +456,7 @@ namespace PdfSharper.Pdf.AcroForms
                     if (text.Length > 0)
                     {
                         var xRect = new XRect(rect.X1, elementPage.Height.Point - rect.Y2, rect.Width, rect.Height);
-                        if ((Flags & PdfAcroFieldFlags.Comb) != 0 && MaxLength > 0)
+                        if ((FieldFlags & PdfAcroFieldFlags.Comb) != 0 && MaxLength > 0)
                         {
                             var combWidth = xRect.Width / MaxLength;
                             format.Comb = true;
@@ -552,7 +550,7 @@ namespace PdfSharper.Pdf.AcroForms
             /// <summary>
             /// Gets the KeysMeta for these keys.
             /// </summary>
-            internal static DictionaryMeta Meta
+            internal static new DictionaryMeta Meta
             {
                 get { return _meta ?? (_meta = CreateMeta(typeof(Keys))); }
             }

--- a/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
@@ -231,11 +231,6 @@ namespace PdfSharper.Pdf.AcroForms
         /// </summary>
         void RenderAppearance()
         {
-            if (string.IsNullOrEmpty(Text))
-            {
-                Elements.Remove(PdfAnnotation.Keys.AP);
-                return;
-            }
 #if true_
             PdfFormXObject xobj = new PdfFormXObject(Owner);
             Owner.Internals.AddObject(xobj);

--- a/src/PdfSharper/Pdf.Annotations/PdfAnnotation.cs
+++ b/src/PdfSharper/Pdf.Annotations/PdfAnnotation.cs
@@ -69,16 +69,6 @@ namespace PdfSharper.Pdf.Annotations
         }
 
         /// <summary>
-        /// Removes an annotation from the document
-        /// <seealso cref="PdfAnnotations.Remove(PdfAnnotation)"/>
-        /// </summary>
-        [Obsolete("Use 'Parent.Remove(this)'")]
-        public void Delete()
-        {
-            Parent.Remove(this);
-        }
-
-        /// <summary>
         /// Gets or sets the annotation flags of this instance.
         /// </summary>
         public PdfAnnotationFlags Flags
@@ -90,16 +80,6 @@ namespace PdfSharper.Pdf.Annotations
                 Elements.SetDateTime(Keys.M, DateTime.Now);
             }
         }
-
-        /// <summary>
-        /// Gets or sets the PdfAnnotations object that this annotation belongs to.
-        /// </summary>
-        public PdfAnnotations Parent
-        {
-            get { return _parent; }
-            set { _parent = value; }
-        }
-        PdfAnnotations _parent;
 
         /// <summary>
         /// Gets or sets the annotation rectangle, defining the location of the annotation

--- a/src/PdfSharper/Pdf.Annotations/PdfWidgetAnnotation.cs
+++ b/src/PdfSharper/Pdf.Annotations/PdfWidgetAnnotation.cs
@@ -32,14 +32,20 @@ namespace PdfSharper.Pdf.Annotations
     /// <summary>
     /// Represents a text annotation.
     /// </summary>
-    internal sealed class PdfWidgetAnnotation : PdfAnnotation
+    public class PdfWidgetAnnotation : PdfAnnotation
     {
-        public PdfWidgetAnnotation()
+        internal PdfWidgetAnnotation()
         {
             Initialize();
         }
 
-        public PdfWidgetAnnotation(PdfDocument document)
+        internal PdfWidgetAnnotation(PdfDictionary dict)
+            : base(dict)
+        {
+        }
+
+
+        internal PdfWidgetAnnotation(PdfDocument document)
             : base(document)
         {
             Initialize();
@@ -53,7 +59,7 @@ namespace PdfSharper.Pdf.Annotations
         /// <summary>
         /// Predefined keys of this dictionary.
         /// </summary>
-        internal new class Keys : PdfAnnotation.Keys
+        public new class Keys : PdfAnnotation.Keys
         {
             /// <summary>
             /// (Optional) The annotation�s highlighting mode, the visual effect to be used when
@@ -79,7 +85,7 @@ namespace PdfSharper.Pdf.Annotations
             [KeyInfo(KeyType.Dictionary | KeyType.Optional)]
             public const string MK = "/MK";
 
-            public static DictionaryMeta Meta
+            internal static DictionaryMeta Meta
             {
                 get { return _meta ?? (_meta = CreateMeta(typeof(Keys))); }
             }


### PR DESCRIPTION
Render a text field even if empty, that way background colors and other things are updated.

Change up the inheritance structure so that fields are widget annotations, this lets object caching take place correctly inside the document acroform fields collections.