### PR TITLE
Feature/incremental updates

### DIFF
--- a/src/PdfSharper-gdi/PdfSharper-gdi.csproj
+++ b/src/PdfSharper-gdi/PdfSharper-gdi.csproj
@@ -993,6 +993,9 @@
     <Compile Include="..\PdfSharper\Pdf\PdfDictionary.cs">
       <Link>Pdf\PdfDictionary.cs</Link>
     </Compile>
+    <Compile Include="..\PdfSharper\Pdf\PdfDirty.cs">
+      <Link>Pdf\PdfDirty.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharper\Pdf\PdfDocument.cs">
       <Link>Pdf\PdfDocument.cs</Link>
     </Compile>

--- a/src/PdfSharper-gdi/PdfSharper-gdi.csproj
+++ b/src/PdfSharper-gdi/PdfSharper-gdi.csproj
@@ -561,6 +561,9 @@
     <Compile Include="..\PdfSharper\Internal\TokenizerHelper.cs">
       <Link>Internal\TokenizerHelper.cs</Link>
     </Compile>
+    <Compile Include="..\PdfSharper\LinqExtensions.cs">
+      <Link>LinqExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharper\Pdf.AcroForms\enums\PdfAcroFieldFlags.cs">
       <Link>Pdf.AcroForms\enums\PdfAcroFieldFlags.cs</Link>
     </Compile>

--- a/src/PdfSharper-wpf/PdfSharper-wpf.csproj
+++ b/src/PdfSharper-wpf/PdfSharper-wpf.csproj
@@ -508,6 +508,9 @@
     <Compile Include="..\PdfSharper\Internal\TokenizerHelper.cs">
       <Link>Internal\TokenizerHelper.cs</Link>
     </Compile>
+    <Compile Include="..\PdfSharper\LinqExtensions.cs">
+      <Link>LinqExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharper\Pdf.AcroForms\enums\PdfAcroFieldFlags.cs">
       <Link>Pdf.AcroForms\enums\PdfAcroFieldFlags.cs</Link>
     </Compile>

--- a/src/PdfSharper-wpf/PdfSharper-wpf.csproj
+++ b/src/PdfSharper-wpf/PdfSharper-wpf.csproj
@@ -937,6 +937,9 @@
     <Compile Include="..\PdfSharper\Pdf\PdfDictionary.cs">
       <Link>Pdf\PdfDictionary.cs</Link>
     </Compile>
+    <Compile Include="..\PdfSharper\Pdf\PdfDirty.cs">
+      <Link>Pdf\PdfDirty.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharper\Pdf\PdfDocument.cs">
       <Link>Pdf\PdfDocument.cs</Link>
     </Compile>

--- a/src/PdfSharper/!internal/Configuration.cs
+++ b/src/PdfSharper/!internal/Configuration.cs
@@ -38,7 +38,7 @@ namespace PdfSharper
     {
         public const string SignificantFigures2 = "0.##";
         public const string SignificantFigures3 = "0.###";
-        public const string SignificantFigures4 = "0.###";
+        public const string SignificantFigures4 = "0.####";
         public const string SignificantFigures7 = "0.0######";
         public const string SignificantFigures10 = "0.##########";
         public const string SignificantFigures1Plus9 = "0.0#########";

--- a/src/PdfSharper/!internal/Configuration.cs
+++ b/src/PdfSharper/!internal/Configuration.cs
@@ -38,8 +38,8 @@ namespace PdfSharper
     {
         public const string SignificantFigures2 = "0.##";
         public const string SignificantFigures3 = "0.###";
-        public const string SignificantFigures4 = "0.####";
-        public const string SignificantFigures7 = "0.#######";
+        public const string SignificantFigures4 = "0.###";
+        public const string SignificantFigures7 = "0.0######";
         public const string SignificantFigures10 = "0.##########";
         public const string SignificantFigures1Plus9 = "0.0#########";
     }

--- a/src/PdfSharper/LinqExtensions.cs
+++ b/src/PdfSharper/LinqExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PdfSharper
+{
+    public static class LinqExtensions
+    {
+        public static IEnumerable<IEnumerable<T>> GroupWhile<T>(this IEnumerable<T> source, Func<T, T, bool> predicate)
+        {
+            using (var iterator = source.GetEnumerator())
+            {
+                if (!iterator.MoveNext())
+                    yield break;
+
+                List<T> list = new List<T>() { iterator.Current };
+
+                T previous = iterator.Current;
+
+                while (iterator.MoveNext())
+                {
+                    if (predicate(previous, iterator.Current))
+                    {
+                        list.Add(iterator.Current);
+                    }
+                    else
+                    {
+                        yield return list;
+                        list = new List<T>() { iterator.Current };
+                    }
+
+                    previous = iterator.Current;
+                }
+                yield return list;
+            }
+        }
+    }
+}

--- a/src/PdfSharper/Pdf.AcroForms/PdfAcroField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfAcroField.cs
@@ -563,6 +563,7 @@ namespace PdfSharper.Pdf.AcroForms
             if (mk == null && (BorderColor != XColor.Empty || BackColor != XColor.Empty))
             {
                 mk = new PdfDictionary(_document);
+                mk.IsCompact = IsCompact;
                 Elements.SetObject(PdfWidgetAnnotation.Keys.MK, mk);
             }
 

--- a/src/PdfSharper/Pdf.AcroForms/PdfSignatureField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfSignatureField.cs
@@ -131,6 +131,7 @@ namespace PdfSharper.Pdf.AcroForms
             if (ap == null)
             {
                 ap = new PdfDictionary(this._document);
+                ap.IsCompact = IsCompact;
                 Elements[PdfAnnotation.Keys.AP] = ap;
             }
 

--- a/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
@@ -391,23 +391,29 @@ namespace PdfSharper.Pdf.AcroForms
                 Elements[PdfAnnotation.Keys.AP] = ap;
             }
 
-            // Set XRef to normal state
-            ap.Elements["/N"] = PdfObject.DeepCopyClosure(Owner, form.PdfForm);
-
-            var normalStateDict = ap.Elements.GetDictionary("/N");
-            var resourceDict = new PdfDictionary(Owner);
-            resourceDict.Elements[PdfResources.Keys.ProcSet] = new PdfArray(Owner, new PdfName("/PDF"), new PdfName("/Text"));
-
-            var defaultFormResources = Owner.AcroForm.Elements.GetDictionary(PdfAcroForm.Keys.DR);
-            if (defaultFormResources != null && defaultFormResources.Elements.ContainsKey(PdfResources.Keys.Font))
+            PdfReference normalStateAppearanceReference = ap.Elements.GetReference("/N");
+            if (normalStateAppearanceReference == null || normalStateAppearanceReference.ObjectNumber == form.PdfForm.ObjectNumber)
             {
-                var fontResourceItem = XForm.GetFontResourceItem(Font.FamilyName, defaultFormResources);
-                PdfDictionary fontDict = new PdfDictionary(Owner);
-                resourceDict.Elements[PdfResources.Keys.Font] = fontDict;
-                fontDict.Elements[fontResourceItem.Key] = fontResourceItem.Value;
-            }
+                //TODO: is this copying too much?
+                // Set XRef to normal state
+                ap.Elements["/N"] = PdfObject.DeepCopyClosure(Owner, form.PdfForm);
 
-            normalStateDict.Elements.SetObject(PdfPage.Keys.Resources, resourceDict);
+
+                var normalStateDict = ap.Elements.GetDictionary("/N");
+                var resourceDict = new PdfDictionary(Owner);
+                resourceDict.Elements[PdfResources.Keys.ProcSet] = new PdfArray(Owner, new PdfName("/PDF"), new PdfName("/Text"));
+
+                var defaultFormResources = Owner.AcroForm.Elements.GetDictionary(PdfAcroForm.Keys.DR);
+                if (defaultFormResources != null && defaultFormResources.Elements.ContainsKey(PdfResources.Keys.Font))
+                {
+                    var fontResourceItem = XForm.GetFontResourceItem(Font.FamilyName, defaultFormResources);
+                    PdfDictionary fontDict = new PdfDictionary(Owner);
+                    resourceDict.Elements[PdfResources.Keys.Font] = fontDict;
+                    fontDict.Elements[fontResourceItem.Key] = fontResourceItem.Value;
+                }
+
+                normalStateDict.Elements.SetObject(PdfPage.Keys.Resources, resourceDict);
+            }
 
             PdfFormXObject xobj = form.PdfForm;
             if (xobj.Stream == null)

--- a/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
@@ -388,6 +388,7 @@ namespace PdfSharper.Pdf.AcroForms
             if (ap == null)
             {
                 ap = new PdfDictionary(_document);
+                ap.IsCompact = IsCompact;
                 Elements[PdfAnnotation.Keys.AP] = ap;
             }
 
@@ -401,6 +402,7 @@ namespace PdfSharper.Pdf.AcroForms
 
                 var normalStateDict = ap.Elements.GetDictionary("/N");
                 var resourceDict = new PdfDictionary(Owner);
+                resourceDict.IsCompact = IsCompact;
                 resourceDict.Elements[PdfResources.Keys.ProcSet] = new PdfArray(Owner, new PdfName("/PDF"), new PdfName("/Text"));
 
                 var defaultFormResources = Owner.AcroForm.Elements.GetDictionary(PdfAcroForm.Keys.DR);
@@ -408,6 +410,7 @@ namespace PdfSharper.Pdf.AcroForms
                 {
                     var fontResourceItem = XForm.GetFontResourceItem(Font.FamilyName, defaultFormResources);
                     PdfDictionary fontDict = new PdfDictionary(Owner);
+                    fontDict.IsCompact = IsCompact;
                     resourceDict.Elements[PdfResources.Keys.Font] = fontDict;
                     fontDict.Elements[fontResourceItem.Key] = fontResourceItem.Value;
                 }

--- a/src/PdfSharper/Pdf.Advanced/PdfCIDFont.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfCIDFont.cs
@@ -107,6 +107,7 @@ namespace PdfSharper.Pdf.Advanced
                 subSet = FontDescriptor._descriptor.FontFace.CreateFontSubSet(_cmapInfo.GlyphIndices, true);
             byte[] fontData = subSet.FontSource.Bytes;
             PdfDictionary fontStream = new PdfDictionary(Owner);
+            fontStream.IsCompact = IsCompact;
             Owner.Internals.AddObject(fontStream);
             FontDescriptor.Elements[PdfFontDescriptor.Keys.FontFile2] = fontStream.Reference;
 

--- a/src/PdfSharper/Pdf.Advanced/PdfCrossReferenceStream.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfCrossReferenceStream.cs
@@ -38,7 +38,7 @@ namespace PdfSharper.Pdf.Advanced
     internal sealed class PdfCrossReferenceStream : PdfTrailer  // Reference: 3.4.7  Cross-Reference Streams / Page 106
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PdfObjectStream"/> class.
+        /// Initializes a new instance of the <see cref="PdfCrossReferenceStream"/> class.
         /// </summary>
         public PdfCrossReferenceStream(PdfDocument document)
             : base(document)

--- a/src/PdfSharper/Pdf.Advanced/PdfCrossReferenceTable.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfCrossReferenceTable.cs
@@ -72,6 +72,8 @@ namespace PdfSharper.Pdf.Advanced
                 throw new InvalidOperationException("Object already in table.");
 
             ObjectTable.Add(iref.ObjectID, iref);
+
+            _maxObjectNumber = Math.Max(_maxObjectNumber, iref.ObjectNumber);
         }
 
         /// <summary>
@@ -289,7 +291,6 @@ namespace PdfSharper.Pdf.Advanced
             foreach (PdfReference iref in irefs)
             {
                 ObjectTable.Add(iref.ObjectID, iref);
-                _maxObjectNumber = Math.Max(_maxObjectNumber, iref.ObjectNumber);
             }
             //CheckConsistence();
             removed -= ObjectTable.Count;

--- a/src/PdfSharper/Pdf.Advanced/PdfCrossReferenceTable.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfCrossReferenceTable.cs
@@ -235,7 +235,7 @@ namespace PdfSharper.Pdf.Advanced
             int removed = ObjectTable.Count;
             //CheckConsistence();
             // We can only compact the last trailer, if at all
-            PdfReference[] irefs = TransitiveClosure(_document._trailers.Last());
+            PdfReference[] irefs = TransitiveClosure(_document._trailer);
 
 #if DEBUG
             // Have any two objects the same ID?

--- a/src/PdfSharper/Pdf.Advanced/PdfCrossReferenceTable.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfCrossReferenceTable.cs
@@ -150,8 +150,7 @@ namespace PdfSharper.Pdf.Advanced
         /// </summary>
         internal void WriteObject(PdfWriter writer)
         {
-            //TODO: write prev entry
-            writer.WriteRaw("xref\n");
+            writer.WriteRaw("xref\r\n");
 
             PdfReference[] irefs = AllReferences;
 
@@ -164,8 +163,8 @@ namespace PdfSharper.Pdf.Advanced
 
             if (irefs.Min(ir => ir.ObjectNumber) > 1)
             {
-                writer.WriteRaw("0 1\n");
-                writer.WriteRaw(String.Format("{0:0000000000} {1:00000} {2} \n", 0, 65535, "f"));
+                writer.WriteRaw("0 1\r\n");
+                writer.WriteRaw(String.Format("{0:0000000000} {1:00000} {2}\r\n", 0, 65535, "f"));
             }
 
             foreach (var xrefGroup in xrefGroupings)
@@ -175,19 +174,19 @@ namespace PdfSharper.Pdf.Advanced
 
                 if (startingObjectNumber == 1)
                 {
-                    writer.WriteRaw(String.Format("0 {0}\n", count + 1));
-                    writer.WriteRaw(String.Format("{0:0000000000} {1:00000} {2} \n", 0, 65535, "f"));
+                    writer.WriteRaw(String.Format("0 {0}\r\n", count + 1));
+                    writer.WriteRaw(String.Format("{0:0000000000} {1:00000} {2}\r\n", 0, 65535, "f"));
                 }
                 else
                 {
-                    writer.WriteRaw(String.Format("{0} {1}\n", startingObjectNumber, count));
+                    writer.WriteRaw(String.Format("{0} {1}\r\n", startingObjectNumber, count));
                 }
 
                 for (int idx = 0; idx < count; idx++)
                 {
                     PdfReference iref = xrefGroup.Irefs[idx];
                     // Acrobat is very pedantic; it must be exactly 20 bytes per line.
-                    writer.WriteRaw(String.Format("{0:0000000000} {1:00000} {2} \n", iref.Position, iref.GenerationNumber, "n"));
+                    writer.WriteRaw(String.Format("{0:0000000000} {1:00000} {2}\r\n", iref.Position, iref.GenerationNumber, "n"));
                 }
             }
 

--- a/src/PdfSharper/Pdf.Advanced/PdfImage.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfImage.cs
@@ -634,6 +634,7 @@ namespace PdfSharper.Pdf.Advanced
                         // Monochrome mask
                         byte[] maskDataCompressed = fd.Encode(idb.BitmapMask, _document.Options.FlateEncodeMode);
                         PdfDictionary pdfMask = new PdfDictionary(_document);
+                        pdfMask.IsCompact = IsCompact;
                         pdfMask.Elements.SetName(Keys.Type, "/XObject");
                         pdfMask.Elements.SetName(Keys.Subtype, "/Image");
 
@@ -724,6 +725,7 @@ namespace PdfSharper.Pdf.Advanced
                 {
                     PdfDictionary colorPalette = null;
                     colorPalette = new PdfDictionary(_document);
+                    colorPalette.IsCompact = IsCompact;
                     byte[] packedPaletteData = idb.PaletteDataLength >= 48 ? fd.Encode(idb.PaletteData, _document.Options.FlateEncodeMode) : null; // don't compress small palettes
                     if (packedPaletteData != null && packedPaletteData.Length + 20 < idb.PaletteDataLength) // +20: compensate for the overhead (estimated value)
                     {
@@ -771,6 +773,7 @@ namespace PdfSharper.Pdf.Advanced
                 // provided for compatibility with older reader versions
                 byte[] maskDataCompressed = fd.Encode(idb.BitmapMask, _document.Options.FlateEncodeMode);
                 PdfDictionary pdfMask = new PdfDictionary(_document);
+                pdfMask.IsCompact = IsCompact;
                 pdfMask.Elements.SetName(Keys.Type, "/XObject");
                 pdfMask.Elements.SetName(Keys.Subtype, "/Image");
 
@@ -789,6 +792,7 @@ namespace PdfSharper.Pdf.Advanced
                 // The image provides an alpha mask (requires Arcrobat 5.0 or higher)
                 byte[] alphaMaskCompressed = fd.Encode(idb.AlphaMask, _document.Options.FlateEncodeMode);
                 PdfDictionary smask = new PdfDictionary(_document);
+                smask.IsCompact = IsCompact;
                 smask.Elements.SetName(Keys.Type, "/XObject");
                 smask.Elements.SetName(Keys.Subtype, "/Image");
 
@@ -969,6 +973,7 @@ namespace PdfSharper.Pdf.Advanced
                     // provided for compatibility with older reader versions
                     byte[] maskDataCompressed = fd.Encode(mask.MaskData, _document.Options.FlateEncodeMode);
                     PdfDictionary pdfMask = new PdfDictionary(_document);
+                    pdfMask.IsCompact = IsCompact;
                     pdfMask.Elements.SetName(Keys.Type, "/XObject");
                     pdfMask.Elements.SetName(Keys.Subtype, "/Image");
 
@@ -987,6 +992,7 @@ namespace PdfSharper.Pdf.Advanced
                     // The image provides an alpha mask (requires Arcrobat 5.0 or higher)
                     byte[] alphaMaskCompressed = fd.Encode(alphaMask, _document.Options.FlateEncodeMode);
                     PdfDictionary smask = new PdfDictionary(_document);
+                    smask.IsCompact = IsCompact;
                     smask.Elements.SetName(Keys.Type, "/XObject");
                     smask.Elements.SetName(Keys.Subtype, "/Image");
 
@@ -1298,6 +1304,7 @@ namespace PdfSharper.Pdf.Advanced
                         // Monochrome mask
                         byte[] maskDataCompressed = fd.Encode(mask.MaskData, _document.Options.FlateEncodeMode);
                         PdfDictionary pdfMask = new PdfDictionary(_document);
+                        pdfMask.IsCompact = IsCompact;
                         pdfMask.Elements.SetName(Keys.Type, "/XObject");
                         pdfMask.Elements.SetName(Keys.Subtype, "/Image");
 
@@ -1388,6 +1395,7 @@ namespace PdfSharper.Pdf.Advanced
                 {
                     PdfDictionary colorPalette = null;
                     colorPalette = new PdfDictionary(_document);
+                    colorPalette.IsCompact = IsCompact;
                     byte[] packedPaletteData = paletteData.Length >= 48 ? fd.Encode(paletteData, _document.Options.FlateEncodeMode) : null; // don't compress small palettes
                     if (packedPaletteData != null && packedPaletteData.Length + 20 < paletteData.Length) // +20: compensate for the overhead (estimated value)
                     {

--- a/src/PdfSharper/Pdf.Advanced/PdfObjectStream.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfObjectStream.cs
@@ -103,18 +103,23 @@ namespace PdfSharper.Pdf.Advanced
                 {
                     GetType();
                 }
+
+                if (!_document._irefTable.Contains(iref.ObjectID))
+                {
+                    _document._irefTable.Add(iref);
+                }
             }
         }
 
         /// <summary>
         /// Reads the compressed object with the specified index.
         /// </summary>
-        internal PdfReference ReadCompressedObject(int index)
+        internal PdfReference ReadCompressedObject(int index, PdfCrossReferenceTable xRefTable)
         {
             Parser parser = new Parser(_document, new MemoryStream(Stream.Value));
             int objectNumber = _header[index][0];
             int offset = _header[index][1];
-            return parser.ReadCompressedObject(objectNumber, offset);
+            return parser.ReadCompressedObject(objectNumber, offset, xRefTable);
         }
 
         /// <summary>

--- a/src/PdfSharper/Pdf.Advanced/PdfObjectStream.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfObjectStream.cs
@@ -108,6 +108,8 @@ namespace PdfSharper.Pdf.Advanced
                 {
                     _document._irefTable.Add(iref);
                 }
+
+                iref.Document = _document;
             }
         }
 

--- a/src/PdfSharper/Pdf.Advanced/PdfTrailer.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfTrailer.cs
@@ -44,6 +44,8 @@ namespace PdfSharper.Pdf.Advanced
     {
         internal PdfCrossReferenceTable XRefTable { get; set; }
 
+        internal bool IsReadOnly { get; set; }
+
         internal int StartXRef { get; set; } = -1;
 
         /// <summary>
@@ -85,6 +87,12 @@ namespace PdfSharper.Pdf.Advanced
         {
             get { return Elements.GetInteger(Keys.Size); }
             set { Elements.SetInteger(Keys.Size, value); }
+        }
+
+        public override void FlagAsDirty()
+        {
+            //trailers are readonly or not
+            //we do not auto clone them for modifications
         }
 
         // TODO: needed when linearized...

--- a/src/PdfSharper/Pdf.Advanced/PdfTrailer.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfTrailer.cs
@@ -251,6 +251,24 @@ namespace PdfSharper.Pdf.Advanced
 
         internal void FixXRefs()
         {
+            IEnumerable<string> keys = Elements.Keys;
+
+            foreach (string key in keys)
+            {
+                PdfItem element = Elements[key];
+                PdfReference iref = element as PdfReference;
+                if (iref != null && iref.Value == null)
+                {
+                    if (!XRefTable.Contains(iref.ObjectID))
+                    { //the document must contain it!
+                        var docIref = _document._irefTable[iref.ObjectID];
+                        Debug.Assert(docIref.Value != null, "Document contains no info, cannot fixup!");
+                        Elements.SetReference(key, docIref);
+                    }
+                    else
+                        Elements.SetReference(key, XRefTable[iref.ObjectID]);
+                }
+            }
             foreach (var item in XRefTable.AllReferences)
             {
                 if (item.Value != null)

--- a/src/PdfSharper/Pdf.Advanced/PdfTrailer.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfTrailer.cs
@@ -95,7 +95,25 @@ namespace PdfSharper.Pdf.Advanced
 
         public PdfDocumentInformation Info
         {
-            get { return (PdfDocumentInformation)Elements.GetValue(Keys.Info, VCF.CreateIndirect); }
+            get
+            {
+
+                var infoReference = Elements.GetReference(Keys.Info);
+                if (infoReference != null && infoReference.Value == null)
+                {
+                    if (!XRefTable.Contains(infoReference.ObjectID))
+                    { //the document must contain it!
+                        var documentInfoReference = _document._irefTable[infoReference.ObjectID];
+                        Debug.Assert(documentInfoReference.Value != null, "Document contains no info, cannot fixup!");
+
+                        Elements.SetReference(Keys.Info, documentInfoReference);
+                    }
+                    else
+                        Elements.SetReference(Keys.Info, XRefTable[infoReference.ObjectID]);
+                }
+
+                return (PdfDocumentInformation)Elements.GetValue(Keys.Info, VCF.CreateIndirect);
+            }
         }
 
         /// <summary>

--- a/src/PdfSharper/Pdf.Advanced/PdfTrailer.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfTrailer.cs
@@ -46,6 +46,8 @@ namespace PdfSharper.Pdf.Advanced
 
         internal int RevisionNumber { get; set; }
 
+        internal int StartXRef { get; set; } = -1;
+
         /// <summary>
         /// Initializes a new instance of PdfTrailer.
         /// </summary>

--- a/src/PdfSharper/Pdf.Advanced/PdfTrailer.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfTrailer.cs
@@ -44,8 +44,6 @@ namespace PdfSharper.Pdf.Advanced
     {
         internal PdfCrossReferenceTable XRefTable { get; set; }
 
-        internal int RevisionNumber { get; set; }
-
         internal int StartXRef { get; set; } = -1;
 
         /// <summary>
@@ -258,7 +256,7 @@ namespace PdfSharper.Pdf.Advanced
                     {
                         if (iref.Value == null)
                         {
-                            PdfObject irefValue = GetObject(_document.GetSortedTrailers(true), iref.ObjectID, RevisionNumber);
+                            PdfObject irefValue = GetObject(_document.GetSortedTrailers(), iref.ObjectID, Info.ModificationDate);
                             if (irefValue.Reference == null)
                             {
                                 iref.Value = irefValue;
@@ -297,7 +295,7 @@ namespace PdfSharper.Pdf.Advanced
                     {
                         if (iref.Value == null)
                         {
-                            PdfObject irefValue = GetObject(_document.GetSortedTrailers(true), iref.ObjectID, RevisionNumber);
+                            PdfObject irefValue = GetObject(_document.GetSortedTrailers(), iref.ObjectID, Info.ModificationDate);
                             if (irefValue.Reference == null)
                             {
                                 iref.Value = irefValue;
@@ -336,11 +334,11 @@ namespace PdfSharper.Pdf.Advanced
             }
         }
 
-        private static PdfObject GetObject(IEnumerable<PdfTrailer> trailers, PdfObjectID objectID, int revision)
+        private static PdfObject GetObject(IEnumerable<PdfTrailer> trailers, PdfObjectID objectID, DateTime revision)
         {
             foreach (PdfTrailer trailer in trailers)
             {
-                if (trailer.RevisionNumber < revision) //return first available object created before the revision
+                if (trailer.Info.ModificationDate < revision) //return first available object created before the revision
                 {
                     continue;
                 }
@@ -355,7 +353,7 @@ namespace PdfSharper.Pdf.Advanced
             //it's not in our revision or any previous revision, get the latest version of it
             foreach (PdfTrailer trailer in trailers)
             {
-                if (trailer.RevisionNumber >= revision)
+                if (trailer.Info.ModificationDate >= revision)
                 {
                     continue;
                 }

--- a/src/PdfSharper/Pdf.Advanced/PdfTrueTypeFont.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfTrueTypeFont.cs
@@ -125,6 +125,7 @@ namespace PdfSharper.Pdf.Advanced
             byte[] fontData = subSet.FontSource.Bytes;
 
             PdfDictionary fontStream = new PdfDictionary(Owner);
+            fontStream.IsCompact = IsCompact;
             Owner.Internals.AddObject(fontStream);
             FontDescriptor.Elements[PdfFontDescriptor.Keys.FontFile2] = fontStream.Reference;
 

--- a/src/PdfSharper/Pdf.IO/Lexer.cs
+++ b/src/PdfSharper/Pdf.IO/Lexer.cs
@@ -199,7 +199,6 @@ namespace PdfSharper.Pdf.IO
             {
                 Array.Resize(ref bytes, read);
             }
-            int endStreamPosition = (int)_pdfSteam.Position;
             // Synchronize idxChar etc.
             Position = (int)_pdfSteam.Position;
 

--- a/src/PdfSharper/Pdf.IO/Lexer.cs
+++ b/src/PdfSharper/Pdf.IO/Lexer.cs
@@ -76,6 +76,8 @@ namespace PdfSharper.Pdf.IO
             }
         }
 
+        internal bool HasReadNewLineOrCarriageReturn = false;
+
         /// <summary>
         /// Reads the next token and returns its type. If the token starts with a digit, the parameter
         /// testReference specifies how to treat it. If it is false, the lexer scans for a single integer.
@@ -175,9 +177,8 @@ namespace PdfSharper.Pdf.IO
         {
             int pos;
 
-            // Skip illegal blanks behind �stream�.
-            while (_currChar == Chars.SP)
-                ScanNextChar(true);
+            // Skip illegal blanks behind �stream�.            
+            MoveToNonSpace();
 
             // Skip new line behind �stream�.
             if (_currChar == Chars.CR)
@@ -198,9 +199,10 @@ namespace PdfSharper.Pdf.IO
             {
                 Array.Resize(ref bytes, read);
             }
-
+            int endStreamPosition = (int)_pdfSteam.Position;
             // Synchronize idxChar etc.
-            Position = pos + read;
+            Position = (int)_pdfSteam.Position;
+
             return bytes;
         }
 
@@ -556,6 +558,7 @@ namespace PdfSharper.Pdf.IO
             Debug.Assert(_currChar == Chars.Less);
 
             _token = new StringBuilder();
+            _hexUpper = false;
             char[] hex = new char[2];
             ScanNextChar(true);
             while (true)
@@ -568,8 +571,13 @@ namespace PdfSharper.Pdf.IO
                 }
                 if (char.IsLetterOrDigit(_currChar))
                 {
-                    hex[0] = char.ToUpper(_currChar);
-                    hex[1] = char.ToUpper(_nextChar);
+                    if (_hexUpper == false && (Char.IsUpper(_currChar) || Char.IsUpper(_nextChar)))
+                    {
+                        _hexUpper = true;
+                    }
+
+                    hex[0] = _currChar;
+                    hex[1] = _nextChar;
                     int ch = int.Parse(new string(hex), NumberStyles.AllowHexSpecifier);
                     _token.Append(Convert.ToChar(ch));
                     ScanNextChar(true);
@@ -700,6 +708,11 @@ namespace PdfSharper.Pdf.IO
         {
             while (_currChar != Chars.EOF)
             {
+                if (_currChar == Chars.LF || _currChar == Chars.CR)
+                {
+                    HasReadNewLineOrCarriageReturn = true;
+                }
+
                 switch (_currChar)
                 {
                     case Chars.NUL:
@@ -717,6 +730,43 @@ namespace PdfSharper.Pdf.IO
                         break;
 
 
+                    default:
+                        return _currChar;
+                }
+            }
+            return _currChar;
+        }
+
+        /// <summary>
+        /// Used to calculate padding put on elements by adobe reader.
+        /// </summary>
+        /// <returns></returns>
+        public char MoveToNonSpace()
+        {
+            while (_currChar != Chars.EOF)
+            {
+                switch (_currChar)
+                {
+                    case Chars.SP:
+                        ScanNextChar(true);
+                        break;
+                    default:
+                        return _currChar;
+                }
+            }
+            return _currChar;
+        }
+
+        public char MoveToNonLineEnding()
+        {
+            while (_currChar != Chars.EOF)
+            {
+                switch (_currChar)
+                {
+                    case Chars.LF:
+                    case Chars.CR:
+                        ScanNextChar(true);
+                        break;
                     default:
                         return _currChar;
                 }
@@ -880,6 +930,7 @@ namespace PdfSharper.Pdf.IO
         char _nextChar;
         StringBuilder _token;
         Symbol _symbol = Symbol.None;
+        internal bool _hexUpper = false;
 
         readonly Stream _pdfSteam;
     }

--- a/src/PdfSharper/Pdf.IO/Parser.cs
+++ b/src/PdfSharper/Pdf.IO/Parser.cs
@@ -1022,14 +1022,27 @@ namespace PdfSharper.Pdf.IO
 #endif
             // Generation is always 0 for compressed objects.
             PdfObjectID objectID = new PdfObjectID(objectNumber);
-            _lexer.Position = offset;
-            PdfObject obj = ReadObject(null, objectID, false, true, false, xRefTable);
 
-            xRefTable[objectID].Value = obj;
+            PdfObject obj = null;
 
-            if (!_document._irefTable.Contains(objectID))
+            //TODO: try get value
+            if (_document._irefTable.Contains(objectID) && _document._irefTable[objectID].Value != null)
             {
-                _document._irefTable.Add(xRefTable[objectID]);
+                xRefTable.Remove(xRefTable[objectID]);
+                xRefTable.Add(_document._irefTable[objectID]);
+                obj = _document._irefTable[objectID].Value;
+            }
+            else
+            {
+                _lexer.Position = offset;
+                obj = ReadObject(null, objectID, false, true, false, xRefTable);
+
+                xRefTable[objectID].Value = obj;
+
+                if (!_document._irefTable.Contains(objectID))
+                {
+                    _document._irefTable.Add(xRefTable[objectID]);
+                }
             }
 
             return obj.Reference;

--- a/src/PdfSharper/Pdf.IO/Parser.cs
+++ b/src/PdfSharper/Pdf.IO/Parser.cs
@@ -113,6 +113,8 @@ namespace PdfSharper.Pdf.IO
         /// <param name="includeReferences">If true, specifies that all indirect objects
         /// are included recursively.</param>
         /// <param name="fromObjecStream">If true, the objects is parsed from an object stream.</param>
+        /// <param name="setObjectID">Automatically add to the document reference table</param>
+        /// <param name="xRefTable">The object table to use when looking for objects by ID.</param>
         public PdfObject ReadObject(PdfObject pdfObject, PdfObjectID objectID, bool includeReferences, bool fromObjecStream, bool setObjectID = true, PdfCrossReferenceTable xRefTable = null)
         {
 #if DEBUG_

--- a/src/PdfSharper/Pdf.IO/Parser.cs
+++ b/src/PdfSharper/Pdf.IO/Parser.cs
@@ -1029,10 +1029,6 @@ namespace PdfSharper.Pdf.IO
             {
                 _document._irefTable.Add(xRefTable[objectID]);
             }
-            else
-            {
-                _document._irefTable[objectID].Value = obj;
-            }
 
             return obj.Reference;
         }
@@ -1401,22 +1397,22 @@ namespace PdfSharper.Pdf.IO
                 }
             }
 
-            foreach (var referenceElement in xrefStream.Elements.Select(e => e.Value).OfType<PdfReference>())
-            {
-                if (!xrefTable.Contains(referenceElement.ObjectID) && !trailerTable.Contains(referenceElement.ObjectID))
-                {
-                    xrefTable.Add(referenceElement);
-                    trailerTable.Add(referenceElement);
-                }
-                else if (!trailerTable.Contains(referenceElement.ObjectID))
-                {
-                    trailerTable.Add(new PdfReference(referenceElement.ObjectID, referenceElement.Position));
-                }
-                else if (!xrefTable.Contains(referenceElement.ObjectID))
-                { //also how?
-                }
+            //foreach (var referenceElement in xrefStream.Elements.Select(e => e.Value).OfType<PdfReference>())
+            //{
+            //    if (!xrefTable.Contains(referenceElement.ObjectID) && !trailerTable.Contains(referenceElement.ObjectID))
+            //    {
+            //        xrefTable.Add(referenceElement);
+            //        trailerTable.Add(referenceElement);
+            //    }
+            //    else if (!trailerTable.Contains(referenceElement.ObjectID))
+            //    {
+            //        trailerTable.Add(new PdfReference(referenceElement.ObjectID, referenceElement.Position));
+            //    }
+            //    else if (!xrefTable.Contains(referenceElement.ObjectID))
+            //    { //also how?
+            //    }
 
-            }
+            //}
 
             trailerTable.IsUnderConstruction = false;
             return xrefStream;

--- a/src/PdfSharper/Pdf.IO/PdfReader.cs
+++ b/src/PdfSharper/Pdf.IO/PdfReader.cs
@@ -464,21 +464,6 @@ namespace PdfSharper.Pdf.IO
             return document;
         }
 
-        private static PdfObject GetLatestRevisionOfObject(IEnumerable<PdfTrailer> trailers, PdfObjectID objectID)
-        {
-            foreach (PdfTrailer trailer in trailers)
-            {
-                PdfReference objRef = trailer.XRefTable[objectID];
-
-                if (objRef != null)
-                {
-                    return objRef.Value;
-                }
-            }
-
-            return null;
-        }
-
         private static void DecompressObjects(PdfDocument document, Parser parser, PdfCrossReferenceTable xRefTable)
         {
             PdfReference[] irefs2 = xRefTable.AllReferences;

--- a/src/PdfSharper/Pdf.IO/PdfReader.cs
+++ b/src/PdfSharper/Pdf.IO/PdfReader.cs
@@ -549,7 +549,6 @@ namespace PdfSharper.Pdf.IO
                         Debug.Assert(xRefTable.Contains(iref.ObjectID));
                         PdfObject pdfObject = parser.ReadObject(null, iref.ObjectID, false, false, false, xRefTable);
 
-                        pdfObject.Reference = iref;
                         iref.Value = pdfObject;
                     }
                     catch (Exception ex)

--- a/src/PdfSharper/Pdf.IO/PdfReader.cs
+++ b/src/PdfSharper/Pdf.IO/PdfReader.cs
@@ -386,6 +386,23 @@ namespace PdfSharper.Pdf.IO
                         trailer.IsReadOnly = true;
                     }
                 }
+                else if (document._trailers.All(t => t is PdfCrossReferenceStream)) //we don't support writing CrossRef streams, flatten them
+                {
+                    document._trailers.Clear();
+                    document._irefTable.Compact();
+
+                    document._trailer = new PdfTrailer((PdfCrossReferenceStream)document._trailer);
+                    document._trailer.XRefTable = document._irefTable;
+
+                    PdfPages pages = document.Pages;
+                    Debug.Assert(pages != null);
+
+                    document._irefTable.CheckConsistence();
+                    document._irefTable.Renumber();
+                    document._irefTable.CheckConsistence();
+
+                    document._trailers.Add(document._trailer);
+                }
 
                 // Encrypt all objects.
                 if (xrefEncrypt != null)

--- a/src/PdfSharper/Pdf.IO/PdfReader.cs
+++ b/src/PdfSharper/Pdf.IO/PdfReader.cs
@@ -358,7 +358,7 @@ namespace PdfSharper.Pdf.IO
                     }
                 }
 
-                foreach (var trailer in document._trailers)
+                foreach (var trailer in document.GetSortedTrailers(true))
                 {
                     ReadObjects(parser, trailer.XRefTable, trailer.RevisionNumber);
                 }

--- a/src/PdfSharper/Pdf.IO/PdfWriter.cs
+++ b/src/PdfSharper/Pdf.IO/PdfWriter.cs
@@ -184,7 +184,7 @@ namespace PdfSharper.Pdf.IO
             PdfStringEncoding encoding = (PdfStringEncoding)(value.Flags & PdfStringFlags.EncodingMask);
             string pdf = (value.Flags & PdfStringFlags.HexLiteral) == 0 ?
                 PdfEncoders.ToStringLiteral(value.Value, encoding, SecurityHandler) :
-                PdfEncoders.ToHexStringLiteral(value.Value, encoding, SecurityHandler, value.PaddingLeft);
+                PdfEncoders.ToHexStringLiteral(value.Value, encoding, SecurityHandler, value.PaddingLeft, value.HexUpperCase);
             WriteRaw(pdf);
 #else
             switch (value.Flags & PdfStringFlags.EncodingMask)
@@ -314,6 +314,7 @@ namespace PdfSharper.Pdf.IO
         /// </summary>
         public void WriteBeginObject(PdfObject obj)
         {
+            PdfDictionary dict = obj as PdfDictionary;
             bool indirect = obj.IsIndirect;
             if (indirect)
             {
@@ -325,10 +326,18 @@ namespace PdfSharper.Pdf.IO
             if (indirect)
             {
                 if (obj is PdfArray)
+                {
                     WriteRaw("[\n");
+                }
                 else if (obj is PdfDictionary)
-                    WriteRaw("<<\n");
-                _lastCat = CharCat.NewLine;
+                {
+                    WriteRaw("<<");
+
+                    if (_layout != PdfWriterLayout.Compact)
+                    {
+                        NewLine();
+                    }
+                }
             }
             else
             {
@@ -336,14 +345,19 @@ namespace PdfSharper.Pdf.IO
                 {
                     WriteSeparator(CharCat.Delimiter);
                     WriteRaw('[');
-                    _lastCat = CharCat.Delimiter;
                 }
                 else if (obj is PdfDictionary)
                 {
-                    NewLine();
-                    WriteSeparator(CharCat.Delimiter);
-                    WriteRaw("<<\n");
-                    _lastCat = CharCat.NewLine;
+                    if (_layout != PdfWriterLayout.Compact)
+                    {
+                        NewLine();
+                        WriteSeparator(CharCat.Delimiter);
+                        WriteRaw("<<\n");
+                    }
+                    else
+                    {
+                        WriteRaw("<<");
+                    }
                 }
             }
             if (_layout == PdfWriterLayout.Verbose)
@@ -383,20 +397,38 @@ namespace PdfSharper.Pdf.IO
                 if (indirect)
                 {
                     if (!stackItem.HasStream)
-                        WriteRaw(_lastCat == CharCat.NewLine ? ">>\n" : " >>\n");
+                    {
+                        if (_layout == PdfWriterLayout.Compact)
+                        {
+                            WriteRaw(">>\r");
+                        }
+                        else
+                        {
+                            WriteRaw(_lastCat == CharCat.NewLine ? ">>\r" : " >>\r");
+                        }
+                    }
                 }
                 else
                 {
                     Debug.Assert(!stackItem.HasStream, "Direct object with stream??");
-                    WriteSeparator(CharCat.NewLine);
-                    WriteRaw(">>\n");
-                    _lastCat = CharCat.NewLine;
+                    if (_layout != PdfWriterLayout.Compact)
+                    {
+                        WriteSeparator(CharCat.NewLine);
+                        WriteRaw(">>\n");
+                    }
+                    else
+                    {
+                        WriteRaw(">>");
+                    }
+
                 }
             }
             if (indirect)
             {
-                NewLine();
-                WriteRaw("endobj\n");
+                if (_lastCat != CharCat.NewLine)
+                    NewLine();
+
+                WriteRaw("endobj\r");
                 if (_layout == PdfWriterLayout.Verbose)
                     WriteRaw("%--------------------------------------------------------------------------------------------------\n");
             }
@@ -411,8 +443,14 @@ namespace PdfSharper.Pdf.IO
             Debug.Assert(stackItem.Object is PdfDictionary);
             Debug.Assert(stackItem.Object.IsIndirect);
             stackItem.HasStream = true;
-
-            WriteRaw(_lastCat == CharCat.NewLine ? ">>\nstream\n" : " >>\nstream\n");
+            if (value.IsCompact)
+            {
+                WriteRaw(">>stream\r\n");
+            }
+            else
+            {
+                WriteRaw(_lastCat == CharCat.NewLine ? ">>\nstream\n" : " >>\nstream\n");
+            }
 
             if (omitStream)
             {
@@ -429,11 +467,15 @@ namespace PdfSharper.Pdf.IO
                         bytes = _securityHandler.EncryptBytes(bytes);
                     }
                     Write(bytes);
+                    if (!string.IsNullOrEmpty(value.Stream.Trailer))
+                    {
+                        WriteRaw(value.Stream.Trailer);
+                    }
                     if (_lastCat != CharCat.NewLine)
-                        WriteRaw('\n');
+                        WriteRaw('\r');
                 }
             }
-            WriteRaw("endstream\n");
+            WriteRaw("endstream\r");
         }
 
         public void WriteRaw(string rawString)
@@ -470,7 +512,7 @@ namespace PdfSharper.Pdf.IO
             //        value.ObjectID.ObjectNumber, value.ObjectID.GenerationNumber,
             //        value.GetType().FullName));
             //else
-            WriteRaw(String.Format("{0} {1} obj\n", value.ObjectID.ObjectNumber, value.ObjectID.GenerationNumber));
+            WriteRaw(String.Format("{0} {1} obj\r", value.ObjectID.ObjectNumber, value.ObjectID.GenerationNumber));
         }
 
         public void WriteFileHeader(PdfDocument document)
@@ -484,9 +526,13 @@ namespace PdfSharper.Pdf.IO
 
         public void WriteEof(PdfDocument document, int startxref)
         {
-            WriteRaw("startxref\n");
+            if (_lastCat != CharCat.NewLine)
+            {
+                WriteRaw("\r\n");
+            }
+            WriteRaw("startxref\r\n");
             WriteRaw(startxref.ToString(CultureInfo.InvariantCulture));
-            WriteRaw("\n%%EOF\n");
+            WriteRaw("\r\n%%EOF\r\n");
             int fileSize = (int)_stream.Position;
         }
 
@@ -559,7 +605,11 @@ namespace PdfSharper.Pdf.IO
                     else
                     {
                         if (cat == CharCat.Character)
-                            _stream.WriteByte((byte)' ');
+                        {
+                            Stream.Seek(-1, SeekOrigin.End);
+                            if (Stream.ReadByte() != 32)//space 
+                                _stream.WriteByte((byte)' ');
+                        }
                     }
                     break;
             }
@@ -580,7 +630,7 @@ namespace PdfSharper.Pdf.IO
         {
             if (Lexer.IsDelimiter(ch))
                 return CharCat.Delimiter;
-            if (ch == Chars.LF)
+            if (ch == Chars.LF || ch == Chars.CR)
                 return CharCat.NewLine;
             return CharCat.Character;
         }

--- a/src/PdfSharper/Pdf.IO/PdfWriter.cs
+++ b/src/PdfSharper/Pdf.IO/PdfWriter.cs
@@ -480,19 +480,6 @@ namespace PdfSharper.Pdf.IO
             header.Append((version / 10).ToString(CultureInfo.InvariantCulture) + "." +
               (version % 10).ToString(CultureInfo.InvariantCulture) + "\n%\xD3\xF4\xCC\xE1\n");
             WriteRaw(header.ToString());
-
-            if (_layout == PdfWriterLayout.Verbose)
-            {
-                WriteRaw(String.Format("% PDFsharp Version {0} (verbose mode)\n", VersionInfo.Version));
-                // Keep some space for later fix-up.
-                _commentPosition = (int)_stream.Position + 2;
-                WriteRaw("%                                                \n");
-                WriteRaw("%                                                \n");
-                WriteRaw("%                                                \n");
-                WriteRaw("%                                                \n");
-                WriteRaw("%                                                \n");
-                WriteRaw("%--------------------------------------------------------------------------------------------------\n");
-            }
         }
 
         public void WriteEof(PdfDocument document, int startxref)
@@ -501,24 +488,6 @@ namespace PdfSharper.Pdf.IO
             WriteRaw(startxref.ToString(CultureInfo.InvariantCulture));
             WriteRaw("\n%%EOF\n");
             int fileSize = (int)_stream.Position;
-            if (_layout == PdfWriterLayout.Verbose)
-            {
-                TimeSpan duration = DateTime.Now - document._creation;
-
-                _stream.Position = _commentPosition;
-                // Without InvariantCulture parameter the following line fails if the current culture is e.g.
-                // a Far East culture, because the date string contains non-ASCII characters.
-                // So never never never never use ToString without a culture info.
-                WriteRaw("Creation date: " + document._creation.ToString("G", CultureInfo.InvariantCulture));
-                _stream.Position = _commentPosition + 50;
-                WriteRaw("Creation time: " + duration.TotalSeconds.ToString("0.000", CultureInfo.InvariantCulture) + " seconds");
-                _stream.Position = _commentPosition + 100;
-                WriteRaw("File size: " + fileSize.ToString(CultureInfo.InvariantCulture) + " bytes");
-                _stream.Position = _commentPosition + 150;
-                WriteRaw("Pages: " + document.Pages.Count.ToString(CultureInfo.InvariantCulture));
-                _stream.Position = _commentPosition + 200;
-                WriteRaw("Objects: " + document._irefTable.ObjectTable.Count.ToString(CultureInfo.InvariantCulture));
-            }
         }
 
         /// <summary>
@@ -652,6 +621,5 @@ namespace PdfSharper.Pdf.IO
         }
 
         readonly List<StackItem> _stack = new List<StackItem>();
-        int _commentPosition;
     }
 }

--- a/src/PdfSharper/Pdf.IO/PdfWriter.cs
+++ b/src/PdfSharper/Pdf.IO/PdfWriter.cs
@@ -465,12 +465,12 @@ namespace PdfSharper.Pdf.IO
 
         void WriteObjectAddress(PdfObject value)
         {
-            if (_layout == PdfWriterLayout.Verbose)
-                WriteRaw(String.Format("{0} {1} obj   % {2}\n",
-                    value.ObjectID.ObjectNumber, value.ObjectID.GenerationNumber,
-                    value.GetType().FullName));
-            else
-                WriteRaw(String.Format("{0} {1} obj\n", value.ObjectID.ObjectNumber, value.ObjectID.GenerationNumber));
+            //if (_layout == PdfWriterLayout.Verbose)
+            //    WriteRaw(String.Format("{0} {1} obj   % {2}\n",
+            //        value.ObjectID.ObjectNumber, value.ObjectID.GenerationNumber,
+            //        value.GetType().FullName));
+            //else
+            WriteRaw(String.Format("{0} {1} obj\n", value.ObjectID.ObjectNumber, value.ObjectID.GenerationNumber));
         }
 
         public void WriteFileHeader(PdfDocument document)

--- a/src/PdfSharper/Pdf.Internal/PdfEncoders.cs
+++ b/src/PdfSharper/Pdf.Internal/PdfEncoders.cs
@@ -250,7 +250,7 @@ namespace PdfSharper.Pdf.Internal
         /// <summary>
         /// Converts a raw string into a raw hexadecimal string literal, possibly encrypted.
         /// </summary>
-        public static string ToHexStringLiteral(string text, PdfStringEncoding encoding, PdfStandardSecurityHandler securityHandler, int paddingLeft)
+        public static string ToHexStringLiteral(string text, PdfStringEncoding encoding, PdfStandardSecurityHandler securityHandler, int paddingLeft, bool upperCase = false)
         {
             if (String.IsNullOrEmpty(text) && paddingLeft == 0)
                 return "<>";
@@ -286,7 +286,7 @@ namespace PdfSharper.Pdf.Internal
                 bytes = tmp;
             }
 
-            byte[] agTemp = FormatStringLiteral(bytes, encoding == PdfStringEncoding.Unicode, true, true, securityHandler);
+            byte[] agTemp = FormatStringLiteral(bytes, encoding == PdfStringEncoding.Unicode, true, true, securityHandler, upperCase ? "{0:X2}" : "{0:x2}");
             return RawEncoding.GetString(agTemp, 0, agTemp.Length);
         }
 
@@ -311,7 +311,7 @@ namespace PdfSharper.Pdf.Internal
         /// <param name="hex">Indicates whether to create a hexadecimal string literal.</param>
         /// <param name="securityHandler">Encrypts the bytes if specified.</param>
         /// <returns>The PDF bytes.</returns>
-        public static byte[] FormatStringLiteral(byte[] bytes, bool unicode, bool prefix, bool hex, PdfStandardSecurityHandler securityHandler)
+        public static byte[] FormatStringLiteral(byte[] bytes, bool unicode, bool prefix, bool hex, PdfStandardSecurityHandler securityHandler, string hexFormat = "{0:x2}")
         {
             if (bytes == null || bytes.Length == 0)
                 return hex ? new byte[] { (byte)'<', (byte)'>' } : new byte[] { (byte)'(', (byte)')' };
@@ -404,7 +404,7 @@ namespace PdfSharper.Pdf.Internal
                 {
                     pdf.Append('<');
                     for (int idx = 0; idx < count; idx++)
-                        pdf.AppendFormat("{0:X2}", bytes[idx]);
+                        pdf.AppendFormat(hexFormat, bytes[idx]);
                     pdf.Append('>');
                 }
             }

--- a/src/PdfSharper/Pdf.Internal/PdfEncoders.cs
+++ b/src/PdfSharper/Pdf.Internal/PdfEncoders.cs
@@ -310,6 +310,7 @@ namespace PdfSharper.Pdf.Internal
         /// <param name="prefix">Indicates whether to use Unicode prefix.</param>
         /// <param name="hex">Indicates whether to create a hexadecimal string literal.</param>
         /// <param name="securityHandler">Encrypts the bytes if specified.</param>
+        /// <param name="hexFormat">either {0:x2} or {0:X2} depending on capitalization.</param>
         /// <returns>The PDF bytes.</returns>
         public static byte[] FormatStringLiteral(byte[] bytes, bool unicode, bool prefix, bool hex, PdfStandardSecurityHandler securityHandler, string hexFormat = "{0:x2}")
         {

--- a/src/PdfSharper/Pdf/PdfArray.cs
+++ b/src/PdfSharper/Pdf/PdfArray.cs
@@ -70,7 +70,7 @@ namespace PdfSharper.Pdf
                 Elements.Add(item);
         }
 
-        
+
         public PdfArray(params PdfItem[] items)
         {
             foreach (PdfItem item in items)
@@ -131,7 +131,9 @@ namespace PdfSharper.Pdf
             get { return _elements ?? (_elements = new ArrayElements(this)); }
         }
 
-        public int PaddingRight { get; private set; }
+        public int PaddingRight { get; internal set; }
+
+        public int PaddingLeft { get; internal set; }
 
         /// <summary>
         /// Returns an enumerator that iterates through a collection.
@@ -163,6 +165,11 @@ namespace PdfSharper.Pdf
         protected override void WriteObject(PdfWriter writer)
         {
             writer.WriteBeginObject(this);
+            if (PaddingLeft > 0)
+            {
+                writer.WriteRaw(new string(' ', PaddingLeft));
+            }
+
             int count = Elements.Count;
             for (int idx = 0; idx < count; idx++)
             {
@@ -172,11 +179,7 @@ namespace PdfSharper.Pdf
             writer.WriteEndObject();
             if (PaddingRight > 0)
             {
-                var bytes = new byte[PaddingRight];
-                for (int i = 0; i < PaddingRight; i++)
-                    bytes[i] = 32;
-
-                writer.Write(bytes);
+                writer.WriteRaw(new string(' ', PaddingRight));
             }
         }
 

--- a/src/PdfSharper/Pdf/PdfDictionary.cs
+++ b/src/PdfSharper/Pdf/PdfDictionary.cs
@@ -73,7 +73,7 @@ namespace PdfSharper.Pdf
     [DebuggerDisplay("{DebuggerDisplay}")]
     public class PdfDictionary : PdfObject, IEnumerable<KeyValuePair<string, PdfItem>>
     {
-        internal bool IsCompact { get; set; }
+        public bool IsCompact { get; set; }
 
         // Reference: 3.2.6  Dictionary Objects / Page 59
 

--- a/src/PdfSharper/Pdf/PdfDirty.cs
+++ b/src/PdfSharper/Pdf/PdfDirty.cs
@@ -1,0 +1,14 @@
+﻿using PdfSharper.Pdf.Advanced;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PdfSharper.Pdf
+{
+    public abstract class PdfDirty
+    {
+        public bool IsDirty { get; protected set; }
+    }
+}

--- a/src/PdfSharper/Pdf/PdfDocument.cs
+++ b/src/PdfSharper/Pdf/PdfDocument.cs
@@ -382,16 +382,6 @@ namespace PdfSharper.Pdf
 
             try
             {
-
-                bool wasPdfCrossRef = false;
-                // HACK: Remove XRefTrailer
-                if (_trailer is PdfCrossReferenceStream)
-                {
-                    _trailer = new PdfTrailer((PdfCrossReferenceStream)_trailer);
-                    _trailer.XRefTable = _irefTable;
-                    wasPdfCrossRef = true;
-                }
-
                 bool encrypt = _securitySettings.DocumentSecurityLevel != PdfDocumentSecurityLevel.None;
                 if (encrypt)
                 {
@@ -434,14 +424,8 @@ namespace PdfSharper.Pdf
 
                 writer.WriteFileHeader(this);
 
-                if (wasPdfCrossRef) //todo: support cross ref writing!
+                if (_trailers.Count == 1) //todo: support cross ref writing!
                 {
-                    _trailers.Clear();
-                    _irefTable.Compact();
-                    _irefTable.CheckConsistence();
-                    _irefTable.Renumber();
-                    _irefTable.CheckConsistence();
-
                     WriteTrailer(writer, _trailer); //HACK! this will lose incremental updates 
                 }
                 else

--- a/src/PdfSharper/Pdf/PdfDocument.cs
+++ b/src/PdfSharper/Pdf/PdfDocument.cs
@@ -473,12 +473,15 @@ namespace PdfSharper.Pdf
             // Let catalog do the rest.
             Catalog.PrepareForSave();
 
-#if true
-            // Remove all unreachable objects (e.g. from deleted pages)
-            int removed = _irefTable.Compact();
-            if (removed != 0)
-                Debug.WriteLine("PrepareForSave: Number of deleted unreachable objects: " + removed);
-            _irefTable.Renumber();
+#if true     
+            if (_openMode == PdfDocumentOpenMode.Modify)
+            {
+                // Remove all unreachable objects (e.g. from deleted pages)
+                int removed = _irefTable.Compact();
+                if (removed != 0)
+                    Debug.WriteLine("PrepareForSave: Number of deleted unreachable objects: " + removed);
+                _irefTable.Renumber();
+            }
 #endif
         }
 
@@ -725,7 +728,7 @@ namespace PdfSharper.Pdf
         /// </summary>
         public PdfAcroForm AcroForm
         {
-            get { return Catalog.AcroForm; }            
+            get { return Catalog.AcroForm; }
         }
 
         /// <summary>

--- a/src/PdfSharper/Pdf/PdfDocument.cs
+++ b/src/PdfSharper/Pdf/PdfDocument.cs
@@ -153,8 +153,11 @@ namespace PdfSharper.Pdf
             _fontTable = new PdfFontTable(this);
             _imageTable = new PdfImageTable(this);
             _trailer = new PdfTrailer(this);
+
             _irefTable = new PdfCrossReferenceTable(this);
+            _trailer.XRefTable = _irefTable;
             _trailer.CreateNewDocumentIDs();
+            _trailers.Add(_trailer);
         }
 
         //~PdfDocument()

--- a/src/PdfSharper/Pdf/PdfItem.cs
+++ b/src/PdfSharper/Pdf/PdfItem.cs
@@ -39,7 +39,7 @@ namespace PdfSharper.Pdf
     /// <summary>
     /// The base class of all PDF objects and simple PDF types.
     /// </summary>
-    public abstract class PdfItem : ICloneable
+    public abstract class PdfItem : PdfDirty, ICloneable
     {
         // All simple types (i.e. derived from PdfItem but not from PdfObject) must be immutable.
         internal event EventHandler<PdfItemEventArgs> BeforeWrite;

--- a/src/PdfSharper/Pdf/PdfPage.cs
+++ b/src/PdfSharper/Pdf/PdfPage.cs
@@ -593,7 +593,7 @@ namespace PdfSharper.Pdf
             if (TransparencyUsed && !Elements.ContainsKey(Keys.Group) &&
                 _document.Options.ColorMode != PdfColorMode.Undefined)
             {
-                PdfDictionary group = new PdfDictionary();
+                PdfDictionary group = new PdfDictionary(Owner);
                 _elements["/Group"] = group;
                 if (_document.Options.ColorMode != PdfColorMode.Cmyk)
                     group.Elements.SetName("/CS", "/DeviceRGB");

--- a/src/PdfSharper/Pdf/PdfPage.cs
+++ b/src/PdfSharper/Pdf/PdfPage.cs
@@ -594,6 +594,7 @@ namespace PdfSharper.Pdf
                 _document.Options.ColorMode != PdfColorMode.Undefined)
             {
                 PdfDictionary group = new PdfDictionary(Owner);
+                group.IsCompact = IsCompact;
                 _elements["/Group"] = group;
                 if (_document.Options.ColorMode != PdfColorMode.Cmyk)
                     group.Elements.SetName("/CS", "/DeviceRGB");

--- a/src/PdfSharper/Pdf/PdfPages.cs
+++ b/src/PdfSharper/Pdf/PdfPages.cs
@@ -74,7 +74,17 @@ namespace PdfSharper.Pdf
 
                 PdfDictionary dict = (PdfDictionary)((PdfReference)PagesArray.Elements[index]).Value;
                 if (!(dict is PdfPage))
-                    dict = new PdfPage(dict);
+                {
+                    Owner.UnderConstruction = true;
+                    try
+                    {
+                        dict = new PdfPage(dict);
+                    }
+                    finally
+                    {
+                        Owner.UnderConstruction = false;
+                    }
+                }
                 return (PdfPage)dict;
             }
         }

--- a/src/PdfSharper/Pdf/PdfString.cs
+++ b/src/PdfSharper/Pdf/PdfString.cs
@@ -166,11 +166,12 @@ namespace PdfSharper.Pdf
             _flags = (PdfStringFlags)encoding;
         }
 
-        internal PdfString(string value, PdfStringFlags flags, int paddingLeft = 0)
+        internal PdfString(string value, PdfStringFlags flags, int paddingLeft = 0, bool isUpper = false)
         {
             _value = value;
             _flags = flags;
-			this.PaddingLeft = paddingLeft;
+            PaddingLeft = paddingLeft;
+            HexUpperCase = isUpper;
         }
 
         /// <summary>
@@ -202,6 +203,8 @@ namespace PdfSharper.Pdf
             get { return _flags; }
         }
         readonly PdfStringFlags _flags;
+
+        internal bool HexUpperCase { get; private set; }
 
         /// <summary>
         /// Gets the string value.

--- a/src/PdfSharper/PdfSharper.csproj
+++ b/src/PdfSharper/PdfSharper.csproj
@@ -192,6 +192,7 @@
     <Compile Include="Internal\DoubleUtil.cs" />
     <Compile Include="Internal\NativeMethods.cs" />
     <Compile Include="Internal\TokenizerHelper.cs" />
+    <Compile Include="LinqExtensions.cs" />
     <Compile Include="Pdf.AcroForms\enums\PdfAcroFieldFlags.cs" />
     <Compile Include="Pdf.AcroForms\enums\PdfAcroFieldType.cs" />
     <Compile Include="Pdf.AcroForms\PdfAcroField.cs" />

--- a/src/PdfSharper/PdfSharper.csproj
+++ b/src/PdfSharper/PdfSharper.csproj
@@ -327,6 +327,7 @@
     <Compile Include="Pdf\enums\PdfPageMode.cs" />
     <Compile Include="Pdf\enums\PdfReadingDirection.cs" />
     <Compile Include="Pdf\enums\PdfTextStringEncoding.cs" />
+    <Compile Include="Pdf\PdfDirty.cs" />
     <Compile Include="Pdf\KeysBase.cs" />
     <Compile Include="Pdf\KeysMeta.cs" />
     <Compile Include="Pdf\PdfArray.cs" />


### PR DESCRIPTION
Loading a document with no incremental updates we "flatten" it out to one object table for modifications, this allows compaction. Loading a document with incremental updates present, we track those in separate tables and write the file with incremental updates.  This is necessary to prevent digital signatures from going invalid.