### PR TITLE
Track all colors with full floating point precision

### DIFF
--- a/src/PdfSharper/Drawing/XColor.cs
+++ b/src/PdfSharper/Drawing/XColor.cs
@@ -69,7 +69,7 @@ namespace PdfSharper.Drawing
             //_cs.GetType(); // Suppress warning
         }
 
-        XColor(byte alpha, byte red, byte green, byte blue)
+        XColor(byte alpha, float red, float green, float blue)
         {
             _cs = XColorSpace.Rgb;
             _a = alpha / 255f;
@@ -180,24 +180,17 @@ namespace PdfSharper.Drawing
         /// Creates an XColor structure from the specified 8-bit color values (red, green, and blue).
         /// The alpha value is implicitly 255 (fully opaque).
         /// </summary>
-        public static XColor FromArgb(int red, int green, int blue)
+        public static XColor FromArgb(float red, float green, float blue)
         {
-            CheckByte(red, "red");
-            CheckByte(green, "green");
-            CheckByte(blue, "blue");
-            return new XColor(255, (byte)red, (byte)green, (byte)blue);
+            return new XColor(255, red, green, blue);
         }
 
         /// <summary>
         /// Creates an XColor structure from the four ARGB component (alpha, red, green, and blue) values.
         /// </summary>
-        public static XColor FromArgb(int alpha, int red, int green, int blue)
+        public static XColor FromArgb(float alpha, float red, float green, float blue)
         {
-            CheckByte(alpha, "alpha");
-            CheckByte(red, "red");
-            CheckByte(green, "green");
-            CheckByte(blue, "blue");
-            return new XColor((byte)alpha, (byte)red, (byte)green, (byte)blue);
+            return new XColor(alpha, red, green, blue);
         }
 
 #if GDI
@@ -422,9 +415,12 @@ namespace PdfSharper.Drawing
         /// </summary>
         public override int GetHashCode()
         {
-            // ReSharper disable NonReadonlyFieldInGetHashCode
-            return ((byte)(_a * 255)) ^ _r ^ _g ^ _b;
-            // ReSharper restore NonReadonlyFieldInGetHashCode
+            int hash = 17;
+            // Suitable nullity checks etc, of course :)
+            hash = hash * 23 + _r.GetHashCode();
+            hash = hash * 23 + _g.GetHashCode();
+            hash = hash * 23 + _b.GetHashCode();
+            return hash;
         }
 
         /// <summary>
@@ -570,9 +566,9 @@ namespace PdfSharper.Drawing
         {
             // ReSharper disable LocalVariableHidesMember
             _cs = XColorSpace.Rgb;
-            int c = 255 - _r;
-            int m = 255 - _g;
-            int y = 255 - _b;
+            int c = 255 - (byte)(_r * 255);
+            int m = 255 - (byte)(_g * 255);
+            int y = 255 - (byte)(_b * 255);
             int k = Math.Min(c, Math.Min(m, y));
             if (k == 255)
                 _c = _m = _y = 0;
@@ -639,7 +635,7 @@ namespace PdfSharper.Drawing
         /// <summary>
         /// Gets or sets the red value.
         /// </summary>
-        public byte R
+        public float R
         {
             get { return _r; }
             set { _r = value; RgbChanged(); }
@@ -648,7 +644,7 @@ namespace PdfSharper.Drawing
         /// <summary>
         /// Gets or sets the green value.
         /// </summary>
-        public byte G
+        public float G
         {
             get { return _g; }
             set { _g = value; RgbChanged(); }
@@ -657,7 +653,7 @@ namespace PdfSharper.Drawing
         /// <summary>
         /// Gets or sets the blue value.
         /// </summary>
-        public byte B
+        public float B
         {
             get { return _b; }
             set { _b = value; RgbChanged(); }
@@ -668,7 +664,14 @@ namespace PdfSharper.Drawing
         /// </summary>
         internal uint Rgb
         {
-            get { return ((uint)_r << 16) | ((uint)_g << 8) | _b; }
+            get
+            {
+                byte r = (byte)(_r * 255);
+                byte g = (byte)(_g * 255);
+                byte b = (byte)(_b * 255);
+
+                return ((uint)r << 16) | ((uint)g << 8) | b;
+            }
         }
 
         /// <summary>
@@ -676,7 +679,16 @@ namespace PdfSharper.Drawing
         /// </summary>
         internal uint Argb
         {
-            get { return ((uint)(_a * 255) << 24) | ((uint)_r << 16) | ((uint)_g << 8) | _b; }
+
+            get
+            {
+                byte a = (byte)(_a * 255);
+                byte r = (byte)(_r * 255);
+                byte g = (byte)(_g * 255);
+                byte b = (byte)(_b * 255);
+
+                return ((uint)a << 24) | ((uint)r << 16) | ((uint)g << 8) | b;
+            }
         }
 
         /// <summary>
@@ -778,9 +790,9 @@ namespace PdfSharper.Drawing
             switch (ColorSpace)
             {
                 case XColorSpace.Rgb:
-                    array.Elements.Add(new PdfReal(R / 255d));
-                    array.Elements.Add(new PdfReal(G / 255d));
-                    array.Elements.Add(new PdfReal(B / 255d));
+                    array.Elements.Add(new PdfReal(R));
+                    array.Elements.Add(new PdfReal(G));
+                    array.Elements.Add(new PdfReal(B));
                     break;
                 case XColorSpace.Cmyk:
                     array.Elements.Add(new PdfReal(C));
@@ -836,9 +848,9 @@ namespace PdfSharper.Drawing
 
         float _a;  // alpha
 
-        byte _r;   // \
-        byte _g;   // |--- RGB
-        byte _b;   // /
+        float _r;   // \
+        float _g;   // |--- RGB
+        float _b;   // /
 
         float _c;  // \
         float _m;  // |--- CMYK

--- a/src/PdfSharper/Drawing/XForm.cs
+++ b/src/PdfSharper/Drawing/XForm.cs
@@ -496,11 +496,13 @@ namespace PdfSharper.Drawing
 
         internal static KeyValuePair<string, PdfItem> GetFontResourceItem(string familyName, PdfDictionary defaultFormResources)
         {
+            familyName = familyName.TrimStart('/');
             var fontList = defaultFormResources.Elements.GetDictionary(PdfResources.Keys.Font);
 
-            var font = fontList.Elements.FirstOrDefault(e => e.Key == familyName ||
+            var font = fontList.Elements.FirstOrDefault(e => e.Key.TrimStart('/') == familyName ||
                                                         fontList.Elements.GetDictionary(e.Key).Elements.GetName(PdfFont.Keys.BaseFont).TrimStart('/') ==
                                                         familyName);
+
             return font;
         }
 

--- a/src/PdfSharper/Pdf.AcroForms/PdfAcroField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfAcroField.cs
@@ -54,6 +54,23 @@ namespace PdfSharper.Pdf.AcroForms
             : base(document)
         {
             _needsAppearances = needsAppearance;
+            SetDefaultFont();
+        }
+
+        private void SetDefaultFont()
+        {
+            var defaultFormResources = Owner.AcroForm.Elements.GetDictionary(PdfAcroForm.Keys.DR);
+            if (defaultFormResources != null && defaultFormResources.Elements.ContainsKey(PdfResources.Keys.Font))
+            {
+                var fontResourceItem = XForm.GetFontResourceItem("Arial", defaultFormResources);
+                if (string.IsNullOrEmpty(fontResourceItem.Key))
+                {
+                    fontResourceItem = XForm.GetFontResourceItem("Helvetica", defaultFormResources);
+                }
+
+                Debug.Assert(!string.IsNullOrEmpty(fontResourceItem.Key), "Unable to find a default font");
+                font = new XFont(fontResourceItem.Key.TrimStart('/'), 10);
+            }
         }
 
         /// <summary>
@@ -62,7 +79,12 @@ namespace PdfSharper.Pdf.AcroForms
         protected PdfAcroField(PdfDictionary dict)
             : base(dict)
         {
+
             DetermineAppearance();
+            if (font == null)
+            {
+                SetDefaultFont();
+            }
         }
 
         /// <summary>
@@ -145,7 +167,7 @@ namespace PdfSharper.Pdf.AcroForms
             }
         }
 
-        XFont font = new XFont("Arial", 10);
+        XFont font;
 
         /// <summary>
         /// Gets the font name that was obtained by analyzing the Fields' content-stream.
@@ -626,7 +648,7 @@ namespace PdfSharper.Pdf.AcroForms
                         else if (bc.Elements.Count == 1)
                             borderColor = XColor.FromGrayScale(bc.Elements.GetReal(0));
                         else if (bc.Elements.Count == 3)
-                            borderColor = XColor.FromArgb((int)(bc.Elements.GetReal(0) * 255.0), (int)(bc.Elements.GetReal(1) * 255.0), (int)(bc.Elements.GetReal(2) * 255.0));
+                            borderColor = XColor.FromArgb((float)bc.Elements.GetReal(0), (float)bc.Elements.GetReal(1), (float)bc.Elements.GetReal(2));
                         else if (bc.Elements.Count == 4)
                             borderColor = XColor.FromCmyk(bc.Elements.GetReal(0), bc.Elements.GetReal(1), bc.Elements.GetReal(2), bc.Elements.GetReal(3));
 
@@ -636,7 +658,7 @@ namespace PdfSharper.Pdf.AcroForms
                         else if (bg.Elements.Count == 1)
                             backColor = XColor.FromGrayScale(bg.Elements.GetReal(0));
                         else if (bg.Elements.Count == 3)
-                            backColor = XColor.FromArgb((int)(bg.Elements.GetReal(0) * 255.0), (int)(bg.Elements.GetReal(1) * 255.0), (int)(bg.Elements.GetReal(2) * 255.0));
+                            backColor = XColor.FromArgb((float)bg.Elements.GetReal(0), (float)bg.Elements.GetReal(1), (float)bg.Elements.GetReal(2));
                         else if (bg.Elements.Count == 4)
                             backColor = XColor.FromCmyk(bg.Elements.GetReal(0), bg.Elements.GetReal(1), bg.Elements.GetReal(2), bg.Elements.GetReal(3));
                     }

--- a/src/PdfSharper/Pdf.Advanced/PdfReference.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfReference.cs
@@ -208,6 +208,10 @@ namespace PdfSharper.Pdf.Advanced
         {
             return _objectID + " R";
         }
+        public override int GetHashCode()
+        {
+            return _objectID.GetHashCode();
+        }
 
         internal static PdfReferenceComparer Comparer
         {

--- a/src/PdfSharper/Pdf.IO/Parser.cs
+++ b/src/PdfSharper/Pdf.IO/Parser.cs
@@ -364,7 +364,7 @@ namespace PdfSharper.Pdf.IO
                 return Convert.ToInt32(value);
 
             PdfReference reference = value as PdfReference;
-            if (reference != null)
+            if (reference != null && reference.Value == null)
             {
                 ParserState state = SaveState();
                 object length = ReadObject(null, reference.ObjectID, false, false);
@@ -372,6 +372,13 @@ namespace PdfSharper.Pdf.IO
                 int len = ((PdfIntegerObject)length).Value;
                 dict.Elements["/Length"] = new PdfInteger(len);
                 return len;
+            }
+            else if (reference != null && reference.Value != null)
+            {
+                if (reference.Value is PdfIntegerObject)
+                {
+                    return ((PdfIntegerObject)reference.Value).Value;
+                }
             }
             throw new InvalidOperationException("Cannot retrieve stream length.");
         }
@@ -1182,7 +1189,7 @@ namespace PdfSharper.Pdf.IO
                                 objReference.Document = _document;
 
                             }
-                            else
+                            else// if (!trailerTable.Contains(objectID))
                             {
                                 PdfReference objReference = new PdfReference(objectID, position);
                                 trailerTable.Add(objReference);

--- a/src/PdfSharper/Pdf.IO/PdfReader.cs
+++ b/src/PdfSharper/Pdf.IO/PdfReader.cs
@@ -423,7 +423,7 @@ namespace PdfSharper.Pdf.IO
                 document.xrefTable.CheckConsistence();
 #endif
 
-                if (openmode == PdfDocumentOpenMode.Modify)
+                if ((document._openMode == PdfDocumentOpenMode.Modify || document._trailers.Count == 1) && !document._trailers.Any(t => t.IsReadOnly))
                 {
                     // Create new or change existing document IDs.
                     if (document.Internals.SecondDocumentID == "")

--- a/src/PdfSharper/Pdf/PdfArray.cs
+++ b/src/PdfSharper/Pdf/PdfArray.cs
@@ -183,6 +183,16 @@ namespace PdfSharper.Pdf
             }
         }
 
+        public override int GetHashCode()
+        {
+            int hash = 17;
+            foreach (var e in Elements)
+            {
+                hash = hash * 23 + e.GetHashCode();
+            }
+            return hash;
+        }
+
         /// <summary>
         /// Represents the elements of an PdfArray.
         /// </summary>

--- a/src/PdfSharper/Pdf/PdfBoolean.cs
+++ b/src/PdfSharper/Pdf/PdfBoolean.cs
@@ -27,6 +27,7 @@
 // DEALINGS IN THE SOFTWARE.
 #endregion
 
+using System;
 using System.Diagnostics;
 using PdfSharper.Pdf.IO;
 
@@ -86,6 +87,11 @@ namespace PdfSharper.Pdf
         protected override void WriteObject(PdfWriter writer)
         {
             writer.Write(this);
+        }
+
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
         }
     }
 }

--- a/src/PdfSharper/Pdf/PdfBooleanObject.cs
+++ b/src/PdfSharper/Pdf/PdfBooleanObject.cs
@@ -27,6 +27,7 @@
 // DEALINGS IN THE SOFTWARE.
 #endregion
 
+using System;
 using System.Diagnostics;
 using PdfSharper.Pdf.IO;
 
@@ -89,6 +90,11 @@ namespace PdfSharper.Pdf
             writer.WriteBeginObject(this);
             writer.Write(_value);
             writer.WriteEndObject();
+        }
+
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
         }
     }
 }

--- a/src/PdfSharper/Pdf/PdfDate.cs
+++ b/src/PdfSharper/Pdf/PdfDate.cs
@@ -87,5 +87,10 @@ namespace PdfSharper.Pdf
         {
             writer.WriteDocString(ToString());
         }
+
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
     }
 }

--- a/src/PdfSharper/Pdf/PdfDocument.cs
+++ b/src/PdfSharper/Pdf/PdfDocument.cs
@@ -416,7 +416,10 @@ namespace PdfSharper.Pdf
                         PdfReference[] allIds = _irefTable.AllReferences;
                         for (int i = maxObjectNumber; i < _irefTable._maxObjectNumber; i++)
                         {
-                            writeableTrailer.XRefTable.Add(allIds[i]);
+                            if (!writeableTrailer.XRefTable.Contains(allIds[i].ObjectID))
+                            {
+                                writeableTrailer.XRefTable.Add(allIds[i]);
+                            }
                         }
                     }
                 }
@@ -552,7 +555,7 @@ namespace PdfSharper.Pdf
             Catalog.PrepareForSave();
 
 #if true     
-            if (_openMode == PdfDocumentOpenMode.Modify || _trailers.Count == 1)
+            if ((_openMode == PdfDocumentOpenMode.Modify || _trailers.Count == 1) && !_trailers.Any(t => t.IsReadOnly))
             {
                 // Remove all unreachable objects (e.g. from deleted pages)
                 int removed = _irefTable.Compact();
@@ -1052,6 +1055,12 @@ namespace PdfSharper.Pdf
             {
                 return !(left == right);
             }
+        }
+
+
+        public override int GetHashCode()
+        {
+            return Guid.GetHashCode();
         }
     }
 }

--- a/src/PdfSharper/Pdf/PdfInteger.cs
+++ b/src/PdfSharper/Pdf/PdfInteger.cs
@@ -81,6 +81,11 @@ namespace PdfSharper.Pdf
             writer.Write(this);
         }
 
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
+
         #region IConvertible Members
 
         ulong IConvertible.ToUInt64(IFormatProvider provider)

--- a/src/PdfSharper/Pdf/PdfIntegerObject.cs
+++ b/src/PdfSharper/Pdf/PdfIntegerObject.cs
@@ -90,5 +90,10 @@ namespace PdfSharper.Pdf
             writer.Write(_value);
             writer.WriteEndObject();
         }
+
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
     }
 }

--- a/src/PdfSharper/Pdf/PdfItem.cs
+++ b/src/PdfSharper/Pdf/PdfItem.cs
@@ -83,5 +83,16 @@ namespace PdfSharper.Pdf
             this.AfterWrite?.Invoke(this, new PdfItemEventArgs() { Position = writer.Position });
         }
 
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+                return false;
+            if (GetType() != obj.GetType())
+                return false;
+
+            return this.GetHashCode() == obj.GetHashCode();
+        }
+
+        public abstract override int GetHashCode();
     }
 }

--- a/src/PdfSharper/Pdf/PdfLiteral.cs
+++ b/src/PdfSharper/Pdf/PdfLiteral.cs
@@ -97,5 +97,10 @@ namespace PdfSharper.Pdf
         {
             writer.Write(this);
         }
+
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
     }
 }

--- a/src/PdfSharper/Pdf/PdfName.cs
+++ b/src/PdfSharper/Pdf/PdfName.cs
@@ -63,14 +63,6 @@ namespace PdfSharper.Pdf
         }
 
         /// <summary>
-        /// Determines whether the specified object is equal to this name.
-        /// </summary>
-        public override bool Equals(object obj)
-        {
-            return _value.Equals(obj);
-        }
-
-        /// <summary>
         /// Returns the hash code for this instance.
         /// </summary>
         public override int GetHashCode()

--- a/src/PdfSharper/Pdf/PdfNameObject.cs
+++ b/src/PdfSharper/Pdf/PdfNameObject.cs
@@ -66,14 +66,6 @@ namespace PdfSharper.Pdf
         }
 
         /// <summary>
-        /// Determines whether the specified object is equal to the current object.
-        /// </summary>
-        public override bool Equals(object obj)
-        {
-            return _value.Equals(obj);
-        }
-
-        /// <summary>
         /// Serves as a hash function for this type.
         /// </summary>
         public override int GetHashCode()

--- a/src/PdfSharper/Pdf/PdfNull.cs
+++ b/src/PdfSharper/Pdf/PdfNull.cs
@@ -62,5 +62,10 @@ namespace PdfSharper.Pdf
         /// The only instance of this class.
         /// </summary>
         public static readonly PdfNull Value = new PdfNull();
+
+        public override int GetHashCode()
+        {
+            return -1;
+        }
     }
 }

--- a/src/PdfSharper/Pdf/PdfNullObject.cs
+++ b/src/PdfSharper/Pdf/PdfNullObject.cs
@@ -70,5 +70,10 @@ namespace PdfSharper.Pdf
             writer.WriteRaw(" null ");
             writer.WriteEndObject();
         }
+
+        public override int GetHashCode()
+        {
+            return -1;
+        }
     }
 }

--- a/src/PdfSharper/Pdf/PdfOutlineCollection.cs
+++ b/src/PdfSharper/Pdf/PdfOutlineCollection.cs
@@ -334,5 +334,11 @@ namespace PdfSharper.Pdf
         readonly PdfOutline _parent;
 
         readonly List<PdfOutline> _outlines = new List<PdfOutline>();
+
+        public override int GetHashCode()
+        {
+            //TODO: implement me if needed
+            return 0;
+        }
     }
 }

--- a/src/PdfSharper/Pdf/PdfReal.cs
+++ b/src/PdfSharper/Pdf/PdfReal.cs
@@ -79,5 +79,10 @@ namespace PdfSharper.Pdf
         {
             writer.Write(this);
         }
+
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
     }
 }

--- a/src/PdfSharper/Pdf/PdfRealObject.cs
+++ b/src/PdfSharper/Pdf/PdfRealObject.cs
@@ -91,5 +91,10 @@ namespace PdfSharper.Pdf
             writer.Write(_value);
             writer.WriteEndObject();
         }
+
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
     }
 }

--- a/src/PdfSharper/Pdf/PdfString.cs
+++ b/src/PdfSharper/Pdf/PdfString.cs
@@ -309,5 +309,10 @@ namespace PdfSharper.Pdf
         {
             writer.Write(this);
         }
+
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
     }
 }

--- a/src/PdfSharper/Pdf/PdfStringObject.cs
+++ b/src/PdfSharper/Pdf/PdfStringObject.cs
@@ -145,5 +145,10 @@ namespace PdfSharper.Pdf
             writer.Write(new PdfString(_value, _flags));
             writer.WriteEndObject();
         }
+
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
     }
 }

--- a/src/PdfSharper/Pdf/PdfUInteger.cs
+++ b/src/PdfSharper/Pdf/PdfUInteger.cs
@@ -82,6 +82,10 @@ namespace PdfSharper.Pdf
         {
             writer.Write(this);
         }
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
 
         #region IConvertible Members
 

--- a/src/PdfSharper/Pdf/PdfUIntegerObject.cs
+++ b/src/PdfSharper/Pdf/PdfUIntegerObject.cs
@@ -92,5 +92,10 @@ namespace PdfSharper.Pdf
             writer.Write(_value);
             writer.WriteEndObject();
         }
+
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
     }
 }


### PR DESCRIPTION
IsDirty fixes utilizing hashcodes and equals
Find default form field font from the document resources
Handle stream lengths that are refences instead of direct ints
Verify document mode & trailers before setting modification date and producer