### PR TITLE
Handle lazy loaded properties, add a setter to keep them in sync with…

### DIFF
--- a/src/PdfSharper/Pdf.AcroForms/PdfAcroField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfAcroField.cs
@@ -135,6 +135,12 @@ namespace PdfSharper.Pdf.AcroForms
                 }
                 return _parent;
             }
+
+            internal set
+            {
+                _parent = value;
+                Elements.SetReference(Keys.Parent, value);
+            }
         }
         private PdfAcroField _parent;
 
@@ -309,9 +315,9 @@ namespace PdfSharper.Pdf.AcroForms
                 throw new ArgumentException("Field already belongs to another parent.");
 
             Fields.Add(kid, this.Page);
-
-            kid.Elements.SetReference(Keys.Parent, this.Reference);
+            kid.Parent = this;
         }
+
 
         /// <summary>
         /// Gets the names of all descendants of this field.
@@ -990,7 +996,10 @@ namespace PdfSharper.Pdf.AcroForms
                 _document._irefTable.Add(field);
                 page.Annotations.Elements.Add(field); //directly adding to elements prevents cast
                 Elements.Add(field);
+
+                field._parent = null;
             }
+
 
             /// <summary>
             /// Create a derived type like PdfTextField or PdfCheckBox if possible.

--- a/src/PdfSharper/Pdf/PdfObject.cs
+++ b/src/PdfSharper/Pdf/PdfObject.cs
@@ -236,9 +236,9 @@ namespace PdfSharper.Pdf
 
         public virtual void FlagAsDirty()
         {
-            if (IsDirty)
+            if (IsDirty || _document._trailers.Count == 1)
             {
-                return; //we have already cloned ourselves for modification
+                return; //we have already cloned ourselves for modification  or the document is not incrementally updated
             }
 
             PdfTrailer writableTrailer = _document._trailers.SingleOrDefault(t => t.IsReadOnly == false);


### PR DESCRIPTION
Lazy loaded properties need setters so that they do not become desynced with the dictionary.