### PR TITLE
Incremental Update hotfixes to keep digital signatures valid

### DIFF
--- a/src/PdfSharper/Drawing/XColor.cs
+++ b/src/PdfSharper/Drawing/XColor.cs
@@ -767,7 +767,7 @@ namespace PdfSharper.Drawing
         /// Gets or sets the gray scale value.
         /// </summary>
         // ReSharper disable InconsistentNaming
-        public double GS
+        public float GS
         // ReSharper restore InconsistentNaming
         {
             get { return _gs; }
@@ -801,11 +801,26 @@ namespace PdfSharper.Drawing
                     array.Elements.Add(new PdfReal(K));
                     break;
                 case XColorSpace.GrayScale:
-                    array.Elements.Add(new PdfReal(GS));
+                    int roundFactor = NumberOfDecimals(GS);
+                    array.Elements.Add(new PdfReal(Math.Round((double)GS, roundFactor)));
                     break;
             }
 
             return array;
+        }
+
+        private static int NumberOfDecimals(float value)
+        {
+            int places = -1;
+            float testValue;
+
+            do
+            {
+                places++;
+                testValue = (float)Math.Round((decimal)value, places);
+            } while (testValue != value);
+
+            return places;
         }
 
         /// <summary>

--- a/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
@@ -72,8 +72,12 @@ namespace PdfSharper.Pdf.AcroForms
             get { return Elements.GetString(Keys.V); }
             set
             {
+                bool wasDirty = IsDirty;
                 Elements.SetString(Keys.V, value);
-                _needsAppearances = true;
+                if (wasDirty != IsDirty || _document._trailers.Count == 1)
+                {
+                    _needsAppearances = true;
+                }
             }
         }
 
@@ -393,11 +397,10 @@ namespace PdfSharper.Pdf.AcroForms
             }
 
             PdfReference normalStateAppearanceReference = ap.Elements.GetReference("/N");
-            if (normalStateAppearanceReference == null || normalStateAppearanceReference.ObjectNumber == form.PdfForm.ObjectNumber)
+            if (normalStateAppearanceReference == null || _document._trailers.Count > 1) //incremental update mode, must create a new stream
             {
-                //TODO: is this copying too much?
                 // Set XRef to normal state
-                ap.Elements["/N"] = PdfObject.DeepCopyClosure(Owner, form.PdfForm);
+                ap.Elements["/N"] = form.PdfForm;
 
 
                 var normalStateDict = ap.Elements.GetDictionary("/N");

--- a/src/PdfSharper/Pdf.Advanced/PdfTrailer.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfTrailer.cs
@@ -170,6 +170,7 @@ namespace PdfSharper.Pdf.Advanced
         internal PdfArray CreateNewDocumentIDs()
         {
             PdfArray array = new PdfArray(_document);
+            array.IsCompact = true;
             byte[] docID = Guid.NewGuid().ToByteArray();
             string id = PdfEncoders.RawEncoding.GetString(docID, 0, docID.Length);
             array.Elements.Add(new PdfString(id, PdfStringFlags.HexLiteral));

--- a/src/PdfSharper/Pdf.Advanced/PdfType0Font.cs
+++ b/src/PdfSharper/Pdf.Advanced/PdfType0Font.cs
@@ -139,7 +139,6 @@ namespace PdfSharper.Pdf.Advanced
 
             // Use GetGlyphIndices to create the widths array.
             OpenTypeDescriptor descriptor = (OpenTypeDescriptor)FontDescriptor._descriptor;
-            StringBuilder w = new StringBuilder("[");
             if (_cmapInfo != null)
             {
                 int[] glyphIndices = _cmapInfo.GetGlyphIndices();
@@ -151,10 +150,22 @@ namespace PdfSharper.Pdf.Advanced
 
                 //TODO: optimize order of indices
 
+                PdfArray widthsArray = new PdfArray(_document);
+                widthsArray.IsCompact = true;
+
                 for (int idx = 0; idx < count; idx++)
-                    w.AppendFormat("{0}[{1}]", glyphIndices[idx], glyphWidths[idx]);
-                w.Append("]");
-                _descendantFont.Elements.SetValue(PdfCIDFont.Keys.W, new PdfLiteral(w.ToString()));
+                {
+                    widthsArray.Elements.Add(new PdfInteger(glyphIndices[idx]));
+
+                    PdfArray glyphWidth = new PdfArray(_document);
+                    glyphWidth.Elements.Add(new PdfInteger(glyphWidths[idx]));
+                    widthsArray.Elements.Add(glyphWidth);
+                }
+
+
+
+
+                _descendantFont.Elements.SetValue(PdfCIDFont.Keys.W, widthsArray);
 
             }
             _descendantFont.PrepareForSave();

--- a/src/PdfSharper/Pdf.Annotations/PdfAnnotation.cs
+++ b/src/PdfSharper/Pdf.Annotations/PdfAnnotation.cs
@@ -77,7 +77,6 @@ namespace PdfSharper.Pdf.Annotations
             set
             {
                 Elements.SetInteger(Keys.F, (int)value);
-                Elements.SetDateTime(Keys.M, DateTime.Now);
             }
         }
 
@@ -91,7 +90,6 @@ namespace PdfSharper.Pdf.Annotations
             set
             {
                 Elements.SetRectangle(Keys.Rect, value);
-                Elements.SetDateTime(Keys.M, DateTime.Now);
             }
         }
 
@@ -106,7 +104,6 @@ namespace PdfSharper.Pdf.Annotations
             set
             {
                 Elements.SetString(Keys.T, value);
-                Elements.SetDateTime(Keys.M, DateTime.Now);
             }
         }
 
@@ -120,7 +117,6 @@ namespace PdfSharper.Pdf.Annotations
             set
             {
                 Elements.SetString(Keys.Subj, value);
-                Elements.SetDateTime(Keys.M, DateTime.Now);
             }
         }
 
@@ -135,7 +131,6 @@ namespace PdfSharper.Pdf.Annotations
             set
             {
                 Elements.SetString(Keys.Contents, value);
-                Elements.SetDateTime(Keys.M, DateTime.Now);
             }
         }
 
@@ -168,7 +163,6 @@ namespace PdfSharper.Pdf.Annotations
                 // TODO: an array.SetColor(clr) function may be useful here
                 PdfArray array = new PdfArray(Owner, new PdfReal[] { new PdfReal(value.R / 255.0), new PdfReal(value.G / 255.0), new PdfReal(value.B / 255.0) });
                 Elements[Keys.C] = array;
-                Elements.SetDateTime(Keys.M, DateTime.Now);
             }
         }
 
@@ -191,6 +185,20 @@ namespace PdfSharper.Pdf.Annotations
                 if (value < 0 || value > 1)
                     throw new ArgumentOutOfRangeException("value", value, "Opacity must be a value in the range from 0 to 1.");
                 Elements.SetReal(Keys.CA, value);
+            }
+        }
+
+        public override void FlagAsDirty()
+        {
+            if (IsDirty || _document._trailers.Count == 1)
+            {
+                return;
+            }
+
+            base.FlagAsDirty();
+
+            if (!(this is PdfWidgetAnnotation))
+            {
                 Elements.SetDateTime(Keys.M, DateTime.Now);
             }
         }

--- a/src/PdfSharper/Pdf.IO/Lexer.cs
+++ b/src/PdfSharper/Pdf.IO/Lexer.cs
@@ -77,6 +77,7 @@ namespace PdfSharper.Pdf.IO
         }
 
         internal bool HasReadNewLineOrCarriageReturn = false;
+        internal bool HasReadSpace = false;
 
         /// <summary>
         /// Reads the next token and returns its type. If the token starts with a digit, the parameter
@@ -462,7 +463,6 @@ namespace PdfSharper.Pdf.IO
                                 case Chars.LF:
                                     ch = ScanNextChar(false);
                                     continue;
-
                                 default:
                                     if (char.IsDigit(ch))  // First octal character.
                                     {
@@ -710,6 +710,11 @@ namespace PdfSharper.Pdf.IO
                 if (_currChar == Chars.LF || _currChar == Chars.CR)
                 {
                     HasReadNewLineOrCarriageReturn = true;
+                }
+
+                if (_currChar == Chars.SP)
+                {
+                    HasReadSpace = true;
                 }
 
                 switch (_currChar)

--- a/src/PdfSharper/Pdf.IO/Parser.cs
+++ b/src/PdfSharper/Pdf.IO/Parser.cs
@@ -385,6 +385,7 @@ namespace PdfSharper.Pdf.IO
 
         public PdfArray ReadArray(PdfArray array, bool includeReferences, PdfCrossReferenceTable xRefTable)
         {
+            _lexer.HasReadSpace = false;
             Debug.Assert(Symbol == Symbol.BeginArray);
             int arrayStart = _lexer.Position;
             _lexer.MoveToNonSpace();
@@ -413,6 +414,7 @@ namespace PdfSharper.Pdf.IO
                 array.Elements.Add(val);
             }
 
+            array.IsCompact = !_lexer.HasReadSpace;
             return array;
         }
 
@@ -510,7 +512,14 @@ namespace PdfSharper.Pdf.IO
 
                     case Symbol.String:
                         //stack.Shift(new PdfString(lexer.Token, PdfStringFlags.PDFDocEncoding));
-                        _stack.Shift(new PdfString(_lexer.Token, PdfStringFlags.RawEncoding));
+                        if (_lexer.Token.StartsWith("D:"))
+                        {
+                            _stack.Shift(new PdfDate(_lexer.Token));
+                        }
+                        else
+                        {
+                            _stack.Shift(new PdfString(_lexer.Token, PdfStringFlags.RawEncoding));
+                        }
                         break;
 
                     case Symbol.UnicodeString:

--- a/src/PdfSharper/Pdf.IO/PdfWriter.cs
+++ b/src/PdfSharper/Pdf.IO/PdfWriter.cs
@@ -343,7 +343,10 @@ namespace PdfSharper.Pdf.IO
             {
                 if (obj is PdfArray)
                 {
-                    WriteSeparator(CharCat.Delimiter);
+                    if (_layout != PdfWriterLayout.Compact)
+                    {
+                        WriteSeparator(CharCat.Delimiter);
+                    }
                     WriteRaw('[');
                 }
                 else if (obj is PdfDictionary)

--- a/src/PdfSharper/Pdf.Internal/PdfEncoders.cs
+++ b/src/PdfSharper/Pdf.Internal/PdfEncoders.cs
@@ -328,6 +328,7 @@ namespace PdfSharper.Pdf.Internal
             }
 
             int count = bytes.Length;
+            int escapedNewLinesAdded = 0;
             StringBuilder pdf = new StringBuilder();
             if (!unicode)
             {
@@ -336,6 +337,12 @@ namespace PdfSharper.Pdf.Internal
                     pdf.Append("(");
                     for (int idx = 0; idx < count; idx++)
                     {
+                        if ((pdf.Length - escapedNewLinesAdded) % 256 == 0)
+                        {
+                            pdf.Append("\\\r");
+                            escapedNewLinesAdded++;
+                        }
+
                         char ch = (char)bytes[idx];
                         if (ch < 32)
                         {

--- a/src/PdfSharper/Pdf/PdfArray.cs
+++ b/src/PdfSharper/Pdf/PdfArray.cs
@@ -44,6 +44,8 @@ namespace PdfSharper.Pdf
     [DebuggerDisplay("{DebuggerDisplay}")]
     public class PdfArray : PdfObject, IEnumerable<PdfItem>
     {
+        public bool IsCompact { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PdfArray"/> class.
         /// </summary>
@@ -164,22 +166,36 @@ namespace PdfSharper.Pdf
 
         protected override void WriteObject(PdfWriter writer)
         {
-            writer.WriteBeginObject(this);
-            if (PaddingLeft > 0)
+            PdfWriterLayout originalLayout = writer.Layout;
+
+            if (IsCompact)
             {
-                writer.WriteRaw(new string(' ', PaddingLeft));
+                writer.Layout = PdfWriterLayout.Compact;
             }
 
-            int count = Elements.Count;
-            for (int idx = 0; idx < count; idx++)
+            try
             {
-                PdfItem value = Elements[idx];
-                value.Write(writer);
+                writer.WriteBeginObject(this);
+                if (PaddingLeft > 0)
+                {
+                    writer.WriteRaw(new string(' ', PaddingLeft));
+                }
+
+                int count = Elements.Count;
+                for (int idx = 0; idx < count; idx++)
+                {
+                    PdfItem value = Elements[idx];
+                    value.Write(writer);
+                }
+                writer.WriteEndObject();
+                if (PaddingRight > 0)
+                {
+                    writer.WriteRaw(new string(' ', PaddingRight));
+                }
             }
-            writer.WriteEndObject();
-            if (PaddingRight > 0)
+            finally
             {
-                writer.WriteRaw(new string(' ', PaddingRight));
+                writer.Layout = originalLayout;
             }
         }
 

--- a/src/PdfSharper/Pdf/PdfDate.cs
+++ b/src/PdfSharper/Pdf/PdfDate.cs
@@ -76,8 +76,8 @@ namespace PdfSharper.Pdf
         /// </summary>
         public override string ToString()
         {
-            string delta = _value.ToString("zzz").Replace(':', '\'');
-            return String.Format("D:{0:yyyyMMddHHmmss}{1}'", _value, delta);
+            string delta = _value.ToLocalTime().ToString("zzz").Replace(':', '\'');
+            return String.Format("D:{0:yyyyMMddHHmmss}{1}'", _value.ToLocalTime(), delta);
         }
 
         /// <summary>

--- a/src/PdfSharper/Pdf/PdfDictionary.cs
+++ b/src/PdfSharper/Pdf/PdfDictionary.cs
@@ -130,7 +130,7 @@ namespace PdfSharper.Pdf
                 foreach (PdfName name in names)
                 {
                     PdfObject obj = dict._elements[name] as PdfObject;
-                    if (obj != null && deepClone)
+                    if (obj != null && (deepClone || !obj.IsIndirect))
                     {
                         obj = obj.Clone();
                         // Recall that obj.Document is now null.
@@ -775,7 +775,7 @@ namespace PdfSharper.Pdf
             /// </summary>
             public void SetRectangle(string key, PdfRectangle rect)
             {
-                _elements[key] = rect;
+                this[key] = rect;
             }
 
             /// Converts the specified value to XMatrix.
@@ -823,7 +823,7 @@ namespace PdfSharper.Pdf
             /// </summary>
             public void SetMatrix(string key, XMatrix matrix)
             {
-                _elements[key] = PdfLiteral.FromMatrix(matrix);
+                this[key] = PdfLiteral.FromMatrix(matrix);
             }
 
             /// <summary>
@@ -878,7 +878,7 @@ namespace PdfSharper.Pdf
             /// </summary>
             public void SetDateTime(string key, DateTime value)
             {
-                _elements[key] = new PdfDate(value);
+                this[key] = new PdfDate(value);
             }
 
             internal int GetEnumFromName(string key, object defaultValue, bool create)
@@ -908,7 +908,7 @@ namespace PdfSharper.Pdf
             {
                 if (!(value is Enum))
                     throw new ArgumentException("value");
-                _elements[key] = new PdfName("/" + value);
+                this[key] = new PdfName("/" + value);
             }
 
             /// <summary>
@@ -1262,7 +1262,7 @@ namespace PdfSharper.Pdf
                     "You try to set an indirect object directly into a dictionary.");
 
                 // HACK?
-                _elements[key] = value;
+                this[key] = value;
             }
 
             ///// <summary>

--- a/src/PdfSharper/Pdf/PdfDocument.cs
+++ b/src/PdfSharper/Pdf/PdfDocument.cs
@@ -45,21 +45,21 @@ using System.Linq;
 
 namespace PdfSharper.Pdf
 {
-	internal class PdfDocumentEventArgs : EventArgs
-	{
-		public PdfWriter Writer { get; set; }
-	}
-	/// <summary>
-	/// Represents a PDF document.
-	/// </summary>
-	[DebuggerDisplay("(Name={Name})")] // A name makes debugging easier
-	public sealed class PdfDocument : PdfObject, IDisposable
-	{
+    internal class PdfDocumentEventArgs : EventArgs
+    {
+        public PdfWriter Writer { get; set; }
+    }
+    /// <summary>
+    /// Represents a PDF document.
+    /// </summary>
+    [DebuggerDisplay("(Name={Name})")] // A name makes debugging easier
+    public sealed class PdfDocument : PdfObject, IDisposable
+    {
 
-		internal event EventHandler BeforeSave = (s, e) => { };
-		internal event EventHandler<PdfDocumentEventArgs> AfterSave = (s, e) => { };
-		internal DocumentState _state;
-		internal PdfDocumentOpenMode _openMode;
+        internal event EventHandler BeforeSave = (s, e) => { };
+        internal event EventHandler<PdfDocumentEventArgs> AfterSave = (s, e) => { };
+        internal DocumentState _state;
+        internal PdfDocumentOpenMode _openMode;
 
 
 #if DEBUG_
@@ -71,206 +71,206 @@ namespace PdfSharper.Pdf
         }
 #endif
 
-		/// <summary>
-		/// Creates a new PDF document in memory.
-		/// To open an existing PDF file, use the PdfReader class.
-		/// </summary>
-		public PdfDocument()
-		{
-			//PdfDocument.Gob.AttatchDocument(Handle);
+        /// <summary>
+        /// Creates a new PDF document in memory.
+        /// To open an existing PDF file, use the PdfReader class.
+        /// </summary>
+        public PdfDocument()
+        {
+            //PdfDocument.Gob.AttatchDocument(Handle);
 
-			_creation = DateTime.Now;
-			_state = DocumentState.Created;
-			_version = 14;
-			Initialize();
-			Info.CreationDate = _creation;
-		}
+            _creation = DateTime.Now;
+            _state = DocumentState.Created;
+            _version = 14;
+            Initialize();
+            Info.CreationDate = _creation;
+        }
 
-		/// <summary>
-		/// Creates a new PDF document with the specified file name. The file is immediately created and keeps
-		/// locked until the document is closed, at that time the document is saved automatically.
-		/// Do not call Save() for documents created with this constructor, just call Close().
-		/// To open an existing PDF file and import it, use the PdfReader class.
-		/// </summary>
-		public PdfDocument(string filename)
-		{
-			//PdfDocument.Gob.AttatchDocument(Handle);
+        /// <summary>
+        /// Creates a new PDF document with the specified file name. The file is immediately created and keeps
+        /// locked until the document is closed, at that time the document is saved automatically.
+        /// Do not call Save() for documents created with this constructor, just call Close().
+        /// To open an existing PDF file and import it, use the PdfReader class.
+        /// </summary>
+        public PdfDocument(string filename)
+        {
+            //PdfDocument.Gob.AttatchDocument(Handle);
 
-			_creation = DateTime.Now;
-			_state = DocumentState.Created;
-			_version = 14;
-			Initialize();
-			Info.CreationDate = _creation;
+            _creation = DateTime.Now;
+            _state = DocumentState.Created;
+            _version = 14;
+            Initialize();
+            Info.CreationDate = _creation;
 
-			// TODO 4STLA: encapsulate the whole c'tor with #if !NETFX_CORE?
+            // TODO 4STLA: encapsulate the whole c'tor with #if !NETFX_CORE?
 #if !NETFX_CORE
-			_outStream = new FileStream(filename, FileMode.Create);
+            _outStream = new FileStream(filename, FileMode.Create);
 #else
             throw new NotImplementedException();
 #endif
-		}
+        }
 
-		/// <summary>
-		/// Creates a new PDF document using the specified stream.
-		/// The stream won't be used until the document is closed, at that time the document is saved automatically.
-		/// Do not call Save() for documents created with this constructor, just call Close().
-		/// To open an existing PDF file, use the PdfReader class.
-		/// </summary>
-		public PdfDocument(Stream outputStream)
-		{
-			//PdfDocument.Gob.AttatchDocument(Handle);
+        /// <summary>
+        /// Creates a new PDF document using the specified stream.
+        /// The stream won't be used until the document is closed, at that time the document is saved automatically.
+        /// Do not call Save() for documents created with this constructor, just call Close().
+        /// To open an existing PDF file, use the PdfReader class.
+        /// </summary>
+        public PdfDocument(Stream outputStream)
+        {
+            //PdfDocument.Gob.AttatchDocument(Handle);
 
-			_creation = DateTime.Now;
-			_state = DocumentState.Created;
-			Initialize();
-			Info.CreationDate = _creation;
+            _creation = DateTime.Now;
+            _state = DocumentState.Created;
+            Initialize();
+            Info.CreationDate = _creation;
 
-			_outStream = outputStream;
-		}
+            _outStream = outputStream;
+        }
 
-		internal PdfDocument(Lexer lexer)
-		{
-			UnderConstruction = true;
-			//PdfDocument.Gob.AttatchDocument(Handle);
+        internal PdfDocument(Lexer lexer)
+        {
+            UnderConstruction = true;
+            //PdfDocument.Gob.AttatchDocument(Handle);
 
-			_creation = DateTime.Now;
-			_state = DocumentState.Imported;
+            _creation = DateTime.Now;
+            _state = DocumentState.Imported;
 
-			//_info = new PdfInfo(this);
-			//_pages = new PdfPages(this);
-			//_fontTable = new PdfFontTable();
-			//_catalog = new PdfCatalog(this);
-			////_font = new PdfFont();
-			//_objects = new PdfObjectTable(this);
-			//_trailer = new PdfTrailer(this);
-			_irefTable = new PdfCrossReferenceTable(this);
-			_lexer = lexer;
-		}
+            //_info = new PdfInfo(this);
+            //_pages = new PdfPages(this);
+            //_fontTable = new PdfFontTable();
+            //_catalog = new PdfCatalog(this);
+            ////_font = new PdfFont();
+            //_objects = new PdfObjectTable(this);
+            //_trailer = new PdfTrailer(this);
+            _irefTable = new PdfCrossReferenceTable(this);
+            _lexer = lexer;
+        }
 
-		void Initialize()
-		{
-			//_info = new PdfInfo(this);
-			_fontTable = new PdfFontTable(this);
-			_imageTable = new PdfImageTable(this);
-			_trailer = new PdfTrailer(this);
+        void Initialize()
+        {
+            //_info = new PdfInfo(this);
+            _fontTable = new PdfFontTable(this);
+            _imageTable = new PdfImageTable(this);
+            _trailer = new PdfTrailer(this);
 
-			_irefTable = new PdfCrossReferenceTable(this);
-			_trailer.XRefTable = _irefTable;
-			_trailer.CreateNewDocumentIDs();
-			_trailers.Add(_trailer);
-		}
+            _irefTable = new PdfCrossReferenceTable(this);
+            _trailer.XRefTable = _irefTable;
+            _trailer.CreateNewDocumentIDs();
+            _trailers.Add(_trailer);
+        }
 
-		//~PdfDocument()
-		//{
-		//  Dispose(false);
-		//}
+        //~PdfDocument()
+        //{
+        //  Dispose(false);
+        //}
 
-		/// <summary>
-		/// Disposes all references to this document stored in other documents. This function should be called
-		/// for documents you finished importing pages from. Calling Dispose is technically not necessary but
-		/// useful for earlier reclaiming memory of documents you do not need anymore.
-		/// </summary>
-		public void Dispose()
-		{
-			Dispose(true);
-			//GC.SuppressFinalize(this);
-		}
+        /// <summary>
+        /// Disposes all references to this document stored in other documents. This function should be called
+        /// for documents you finished importing pages from. Calling Dispose is technically not necessary but
+        /// useful for earlier reclaiming memory of documents you do not need anymore.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            //GC.SuppressFinalize(this);
+        }
 
-		void Dispose(bool disposing)
-		{
-			if (_state != DocumentState.Disposed)
-			{
-				if (disposing)
-				{
-					// Dispose managed resources.
-				}
-				//PdfDocument.Gob.DetatchDocument(Handle);
-			}
-			_state = DocumentState.Disposed;
-		}
+        void Dispose(bool disposing)
+        {
+            if (_state != DocumentState.Disposed)
+            {
+                if (disposing)
+                {
+                    // Dispose managed resources.
+                }
+                //PdfDocument.Gob.DetatchDocument(Handle);
+            }
+            _state = DocumentState.Disposed;
+        }
 
-		/// <summary>
-		/// Gets or sets a user defined object that contains arbitrary information associated with this document.
-		/// The tag is not used by PdfSharper.
-		/// </summary>
-		public object Tag
-		{
-			get { return _tag; }
-			set { _tag = value; }
-		}
-		object _tag;
+        /// <summary>
+        /// Gets or sets a user defined object that contains arbitrary information associated with this document.
+        /// The tag is not used by PdfSharper.
+        /// </summary>
+        public object Tag
+        {
+            get { return _tag; }
+            set { _tag = value; }
+        }
+        object _tag;
 
-		/// <summary>
-		/// Gets or sets a value used to distinguish PdfDocument objects.
-		/// The name is not used by PdfSharper.
-		/// </summary>
-		string Name
-		{
-			get { return _name; }
-			set { _name = value; }
-		}
-		string _name = NewName();
+        /// <summary>
+        /// Gets or sets a value used to distinguish PdfDocument objects.
+        /// The name is not used by PdfSharper.
+        /// </summary>
+        string Name
+        {
+            get { return _name; }
+            set { _name = value; }
+        }
+        string _name = NewName();
 
-		/// <summary>
-		/// Get a new default name for a new document.
-		/// </summary>
-		static string NewName()
-		{
+        /// <summary>
+        /// Get a new default name for a new document.
+        /// </summary>
+        static string NewName()
+        {
 #if DEBUG_
             if (PdfDocument.nameCount == 57)
                 PdfDocument.nameCount.GetType();
 #endif
-			return "Document " + _nameCount++;
-		}
-		static int _nameCount;
+            return "Document " + _nameCount++;
+        }
+        static int _nameCount;
 
-		internal bool CanModify
-		{
-			//get {return _state == DocumentState.Created || _state == DocumentState.Modifyable;}
-			get { return true; }
-		}
+        internal bool CanModify
+        {
+            //get {return _state == DocumentState.Created || _state == DocumentState.Modifyable;}
+            get { return true; }
+        }
 
-		/// <summary>
-		/// Closes this instance.
-		/// </summary>
-		public void Close()
-		{
-			if (!CanModify)
-				throw new InvalidOperationException(PSSR.CannotModify);
+        /// <summary>
+        /// Closes this instance.
+        /// </summary>
+        public void Close()
+        {
+            if (!CanModify)
+                throw new InvalidOperationException(PSSR.CannotModify);
 
-			if (_outStream != null)
-			{
-				// Get security handler if document gets encrypted
-				PdfStandardSecurityHandler securityHandler = null;
-				if (SecuritySettings.DocumentSecurityLevel != PdfDocumentSecurityLevel.None)
-					securityHandler = SecuritySettings.SecurityHandler;
+            if (_outStream != null)
+            {
+                // Get security handler if document gets encrypted
+                PdfStandardSecurityHandler securityHandler = null;
+                if (SecuritySettings.DocumentSecurityLevel != PdfDocumentSecurityLevel.None)
+                    securityHandler = SecuritySettings.SecurityHandler;
 
-				PdfWriter writer = new PdfWriter(_outStream, securityHandler);
-				try
-				{
-					DoSave(writer);
-				}
-				finally
-				{
-					writer.Close();
-				}
-			}
-		}
+                PdfWriter writer = new PdfWriter(_outStream, securityHandler);
+                try
+                {
+                    DoSave(writer);
+                }
+                finally
+                {
+                    writer.Close();
+                }
+            }
+        }
 
 #if true //!NETFX_CORE
-		/// <summary>
-		/// Saves the document to the specified path. If a file already exists, it will be overwritten.
-		/// </summary>
-		public void Save(string path)
-		{
-			if (!CanModify)
-				throw new InvalidOperationException(PSSR.CannotModify);
+        /// <summary>
+        /// Saves the document to the specified path. If a file already exists, it will be overwritten.
+        /// </summary>
+        public void Save(string path)
+        {
+            if (!CanModify)
+                throw new InvalidOperationException(PSSR.CannotModify);
 
 #if !NETFX_CORE
-			using (Stream stream = new FileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
-			{
-				Save(stream);
-			}
+            using (Stream stream = new FileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
+            {
+                Save(stream);
+            }
 #else
             var task = SaveAsync(path, true);
 
@@ -284,7 +284,7 @@ namespace PdfSharper.Pdf
             //byte[] pdf = ms.ToArray();
             //ms.Close();
 #endif
-		}
+        }
 #endif
 
 #if NETFX_CORE
@@ -314,757 +314,768 @@ namespace PdfSharper.Pdf
         }
 #endif
 
-		/// <summary>
-		/// Saves the document to the specified stream.
-		/// </summary>
-		public void Save(Stream stream, bool closeStream)
-		{
-			if (!CanModify)
-				throw new InvalidOperationException(PSSR.CannotModify);
+        /// <summary>
+        /// Saves the document to the specified stream.
+        /// </summary>
+        public void Save(Stream stream, bool closeStream)
+        {
+            if (!CanModify)
+                throw new InvalidOperationException(PSSR.CannotModify);
 
-			// TODO: more diagnostic checks
-			string message = "";
-			if (!CanSave(ref message))
-				throw new PdfSharpException(message);
+            // TODO: more diagnostic checks
+            string message = "";
+            if (!CanSave(ref message))
+                throw new PdfSharpException(message);
 
-			// Get security handler if document gets encrypted.
-			PdfStandardSecurityHandler securityHandler = null;
-			if (SecuritySettings.DocumentSecurityLevel != PdfDocumentSecurityLevel.None)
-				securityHandler = SecuritySettings.SecurityHandler;
+            // Get security handler if document gets encrypted.
+            PdfStandardSecurityHandler securityHandler = null;
+            if (SecuritySettings.DocumentSecurityLevel != PdfDocumentSecurityLevel.None)
+                securityHandler = SecuritySettings.SecurityHandler;
 
-			PdfWriter writer = null;
-			try
-			{
-				writer = new PdfWriter(stream, securityHandler);
-				DoSave(writer);
-			}
-			finally
-			{
-				if (stream != null)
-				{
-					if (closeStream)
+            PdfWriter writer = null;
+            try
+            {
+                writer = new PdfWriter(stream, securityHandler);
+                DoSave(writer);
+            }
+            finally
+            {
+                if (stream != null)
+                {
+                    if (closeStream)
 #if UWP
                         stream.Dispose();
 #else
-						stream.Close();
+                        stream.Close();
 #endif
-					else
-						stream.Position = 0; // Reset the stream position if the stream is kept open.
-				}
-				if (writer != null)
-					writer.Close(closeStream);
-			}
-		}
+                    else
+                        stream.Position = 0; // Reset the stream position if the stream is kept open.
+                }
+                if (writer != null)
+                    writer.Close(closeStream);
+            }
+        }
 
-		/// <summary>
-		/// Saves the document to the specified stream.
-		/// The stream is not closed by this function.
-		/// (Older versions of PDFsharp closes the stream. That was not very useful.)
-		/// </summary>
-		public void Save(Stream stream)
-		{
-			Save(stream, false);
-		}
+        /// <summary>
+        /// Saves the document to the specified stream.
+        /// The stream is not closed by this function.
+        /// (Older versions of PDFsharp closes the stream. That was not very useful.)
+        /// </summary>
+        public void Save(Stream stream)
+        {
+            Save(stream, false);
+        }
 
-		/// <summary>
-		/// Implements saving a PDF file.
-		/// </summary>
-		void DoSave(PdfWriter writer)
-		{
-			this.BeforeSave(this, EventArgs.Empty);
+        /// <summary>
+        /// Implements saving a PDF file.
+        /// </summary>
+        void DoSave(PdfWriter writer)
+        {
+            this.BeforeSave(this, EventArgs.Empty);
 
-			if (_pages == null || _pages.Count == 0)
-			{
-				if (_outStream != null)
-				{
-					// Give feedback if the wrong constructor was used.
-					throw new InvalidOperationException("Cannot save a PDF document with no pages. Do not use \"public PdfDocument(string filename)\" or \"public PdfDocument(Stream outputStream)\" if you want to open an existing PDF document from a file or stream; use PdfReader.Open() for that purpose.");
-				}
-				throw new InvalidOperationException("Cannot save a PDF document with no pages.");
-			}
+            if (_pages == null || _pages.Count == 0)
+            {
+                if (_outStream != null)
+                {
+                    // Give feedback if the wrong constructor was used.
+                    throw new InvalidOperationException("Cannot save a PDF document with no pages. Do not use \"public PdfDocument(string filename)\" or \"public PdfDocument(Stream outputStream)\" if you want to open an existing PDF document from a file or stream; use PdfReader.Open() for that purpose.");
+                }
+                throw new InvalidOperationException("Cannot save a PDF document with no pages.");
+            }
 
-			try
-			{
-				bool encrypt = _securitySettings.DocumentSecurityLevel != PdfDocumentSecurityLevel.None;
-				if (encrypt)
-				{
-					PdfStandardSecurityHandler securityHandler = _securitySettings.SecurityHandler;
-					if (securityHandler.Reference == null)
-						_irefTable.Add(securityHandler);
-					else
-						Debug.Assert(_irefTable.Contains(securityHandler.ObjectID));
-					_trailer.Elements[PdfTrailer.Keys.Encrypt] = _securitySettings.SecurityHandler.Reference;
-				}
-				else
-					_trailer.Elements.Remove(PdfTrailer.Keys.Encrypt);
+            try
+            {
+                bool encrypt = _securitySettings.DocumentSecurityLevel != PdfDocumentSecurityLevel.None;
+                if (encrypt)
+                {
+                    PdfStandardSecurityHandler securityHandler = _securitySettings.SecurityHandler;
+                    if (securityHandler.Reference == null)
+                        _irefTable.Add(securityHandler);
+                    else
+                        Debug.Assert(_irefTable.Contains(securityHandler.ObjectID));
+                    _trailer.Elements[PdfTrailer.Keys.Encrypt] = _securitySettings.SecurityHandler.Reference;
+                }
+                else
+                    _trailer.Elements.Remove(PdfTrailer.Keys.Encrypt);
 
-				PrepareForSave();
+                PrepareForSave();
 
-				PdfTrailer writeableTrailer = _trailers.SingleOrDefault(t => t.IsReadOnly == false);
-				if (writeableTrailer != null)
-				{
-					writeableTrailer.Info.ModificationDate = DateTime.Now;
-					PdfTrailer previous = GetSortedTrailers().LastOrDefault(t => t.Info.ModificationDate.ToUniversalTime() < writeableTrailer.Info.ModificationDate.ToUniversalTime());
-					int maxObjectNumber = writeableTrailer.XRefTable._maxObjectNumber;
-					if (previous != null)
-					{
-						maxObjectNumber = previous.XRefTable._maxObjectNumber;
-					}
+                PdfTrailer writeableTrailer = _trailers.SingleOrDefault(t => t.IsReadOnly == false);
+                if (writeableTrailer != null)
+                {
+                    writeableTrailer.Info.ModificationDate = DateTime.Now;
+                    PdfTrailer previous = GetSortedTrailers().LastOrDefault(t => t.Info.ModificationDate.ToUniversalTime() < writeableTrailer.Info.ModificationDate.ToUniversalTime());
+                    int maxObjectNumber = writeableTrailer.XRefTable._maxObjectNumber;
+                    if (previous != null)
+                    {
+                        maxObjectNumber = previous.XRefTable._maxObjectNumber;
+                    }
 
-					if (_irefTable._maxObjectNumber > maxObjectNumber) //new objects were added, put them in the trailer
-					{
-						PdfReference[] allIds = _irefTable.AllReferences;
-						for (int i = maxObjectNumber; i < _irefTable._maxObjectNumber; i++)
-						{
-							if (!writeableTrailer.XRefTable.Contains(allIds[i].ObjectID))
-							{
-								writeableTrailer.XRefTable.Add(allIds[i]);
-							}
-						}
-					}
-				}
-
-
-				if (encrypt)
-					_securitySettings.SecurityHandler.PrepareEncryption();
-
-				writer.WriteFileHeader(this);
-
-				if (_trailers.Count == 1) //todo: support cross ref writing!
-				{
-					WriteTrailer(writer, _trailer); //HACK! this will lose incremental updates 
-				}
-				else
-				{
-					foreach (var trailer in GetSortedTrailers())
-					{
-						WriteTrailer(writer, trailer);
-					}
-				}
-
-				//if (encrypt)
-				//{
-				//  state &= ~DocumentState.SavingEncrypted;
-				//  //_securitySettings.SecurityHandler.EncryptDocument();
-				//}
-			}
-			finally
-			{
-				if (writer != null)
-				{
-					this.AfterSave(this, new PdfDocumentEventArgs() { Writer = writer });
-					writer.Stream.Flush();
-					// DO NOT CLOSE WRITER HERE
-					//writer.Close();
-				}
-			}
-		}
-
-		internal PdfTrailer MakeNewTrailer()
-		{
-			PdfTrailer endingTrailer = new PdfTrailer(this);
-			endingTrailer.XRefTable = new PdfCrossReferenceTable(this);
-
-			PdfDictionary trailerInfo = Info.Clone();
-			trailerInfo.Document = this;
-			PdfReference infoReference = new PdfReference(Info.ObjectID, -1);
-			infoReference.Value = trailerInfo;
-
-			endingTrailer.XRefTable.Add(infoReference);
-
-			endingTrailer.Elements.SetReference(PdfTrailer.Keys.Info, infoReference);
-
-			//TODO: Document trailer root ok?
-			endingTrailer.Elements.SetReference(PdfTrailer.Keys.Root, _trailer.Root);
-
-			string documentID = _trailer.GetDocumentID(1);
-			endingTrailer.SetDocumentID(0, documentID);
+                    if (_irefTable._maxObjectNumber > maxObjectNumber) //new objects were added, put them in the trailer
+                    {
+                        PdfReference[] allIds = _irefTable.AllReferences;
+                        for (int i = maxObjectNumber; i < _irefTable._maxObjectNumber; i++)
+                        {
+                            if (!writeableTrailer.XRefTable.Contains(allIds[i].ObjectID))
+                            {
+                                writeableTrailer.XRefTable.Add(allIds[i]);
+                            }
+                        }
+                    }
+                }
 
 
-			_trailers.Insert(0, endingTrailer);
+                if (encrypt)
+                    _securitySettings.SecurityHandler.PrepareEncryption();
 
-			return endingTrailer;
-		}
+                writer.WriteFileHeader(this);
 
-		private void WriteTrailer(PdfWriter writer, PdfTrailer trailer)
-		{
-			PdfReference[] irefs = trailer.XRefTable.AllReferences;
-			int count = irefs.Length;
-			for (int idx = 0; idx < count; idx++)
-			{
-				PdfReference iref = irefs[idx];
+                if (_trailers.Count == 1) //todo: support cross ref writing!
+                {
+                    WriteTrailer(writer, _trailer); //HACK! this will lose incremental updates 
+                }
+                else
+                {
+                    foreach (var trailer in GetSortedTrailers())
+                    {
+                        WriteTrailer(writer, trailer);
+                    }
+                }
+
+                //if (encrypt)
+                //{
+                //  state &= ~DocumentState.SavingEncrypted;
+                //  //_securitySettings.SecurityHandler.EncryptDocument();
+                //}
+            }
+            finally
+            {
+                if (writer != null)
+                {
+                    this.AfterSave(this, new PdfDocumentEventArgs() { Writer = writer });
+                    writer.Stream.Flush();
+                    // DO NOT CLOSE WRITER HERE
+                    //writer.Close();
+                }
+            }
+        }
+
+        internal PdfTrailer MakeNewTrailer()
+        {
+            PdfTrailer endingTrailer = new PdfTrailer(this);
+            endingTrailer.XRefTable = new PdfCrossReferenceTable(this);
+
+            PdfDictionary trailerInfo = Info.Clone();
+            trailerInfo.Document = this;
+            PdfReference infoReference = new PdfReference(Info.ObjectID, -1);
+            infoReference.Value = trailerInfo;
+
+            endingTrailer.XRefTable.Add(infoReference);
+
+            endingTrailer.Elements.SetReference(PdfTrailer.Keys.Info, infoReference);
+
+            //TODO: Document trailer root ok?
+            endingTrailer.Elements.SetReference(PdfTrailer.Keys.Root, _trailer.Root);
+
+            string documentID = _trailer.GetDocumentID(0);
+            endingTrailer.SetDocumentID(0, documentID);
+
+
+            _trailers.Insert(0, endingTrailer);
+
+            return endingTrailer;
+        }
+
+        private void WriteTrailer(PdfWriter writer, PdfTrailer trailer)
+        {
+            PdfReference[] irefs = trailer.XRefTable.AllReferences;
+            int count = irefs.Length;
+            for (int idx = 0; idx < count; idx++)
+            {
+                PdfReference iref = irefs[idx];
 #if DEBUG_
                     if (iref.ObjectNumber == 378)
                         GetType();
 #endif
-				iref.Position = writer.Position;
-				iref.Value.Write(writer);
-			}
-			trailer.StartXRef = writer.Position;
-			trailer.XRefTable.WriteObject(writer);
-			writer.WriteRaw("trailer\r\n");
+                iref.Position = writer.Position;
+                iref.Value.Write(writer);
+            }
+            trailer.StartXRef = writer.Position;
+            trailer.XRefTable.WriteObject(writer);
+            writer.WriteRaw("trailer\r\n");
 
-			if (trailer.IsReadOnly == false)
-			{
-				trailer.Elements.SetInteger("/Size", trailer.XRefTable._maxObjectNumber + 1); //0 record isn't in count
-			}
+            if (trailer.IsReadOnly == false)
+            {
+                trailer.Elements.SetInteger("/Size", trailer.XRefTable._maxObjectNumber + 1); //0 record isn't in count
+            }
 
-			var previousRevision = GetSortedTrailers().LastOrDefault(t => t.Info.ModificationDate.ToUniversalTime() < trailer.Info.ModificationDate.ToUniversalTime());
-			if (previousRevision != null)
-			{
-				Debug.Assert(previousRevision.StartXRef != -1, "Previous trailer was not written yet");
-				trailer.Elements.SetInteger("/Prev", previousRevision.StartXRef);
-			}
+            var previousRevision = GetSortedTrailers().LastOrDefault(t => t.Info.ModificationDate.ToUniversalTime() < trailer.Info.ModificationDate.ToUniversalTime());
+            if (previousRevision != null)
+            {
+                Debug.Assert(previousRevision.StartXRef != -1, "Previous trailer was not written yet");
+                trailer.Elements.SetInteger("/Prev", previousRevision.StartXRef);
+            }
 
-			trailer.Write(writer);
-			writer.WriteEof(this, trailer.StartXRef);
-		}
+            trailer.Write(writer);
+            writer.WriteEof(this, trailer.StartXRef);
+        }
 
-		/// <summary>
-		/// Dispatches PrepareForSave to the objects that need it.
-		/// </summary>
-		internal override void PrepareForSave()
-		{
-			PdfDocumentInformation info = Info;
+        /// <summary>
+        /// Dispatches PrepareForSave to the objects that need it.
+        /// </summary>
+        internal override void PrepareForSave()
+        {
+            PdfDocumentInformation info = Info;
 
-			// Add patch level to producer if it is not '0'.
-			string pdfSharpProducer = VersionInfo.Producer;
-			if (!ProductVersionInfo.VersionPatch.Equals("0"))
-				pdfSharpProducer = ProductVersionInfo.Producer2;
+            // Add patch level to producer if it is not '0'.
+            string pdfSharpProducer = VersionInfo.Producer;
+            if (!ProductVersionInfo.VersionPatch.Equals("0"))
+                pdfSharpProducer = ProductVersionInfo.Producer2;
 
-			// Set Creator if value is undefined.
-			if (info.Elements[PdfDocumentInformation.Keys.Creator] == null)
-				info.Creator = pdfSharpProducer;
+            // Set Creator if value is undefined.
+            if (info.Elements[PdfDocumentInformation.Keys.Creator] == null)
+                info.Creator = pdfSharpProducer;
 
-			// Keep original producer if file was imported.
-			if (_openMode == PdfDocumentOpenMode.Modify)
-			{
-				string producer = info.Producer;
-				if (producer.Length == 0)
-					producer = pdfSharpProducer;
-				else
-				{
-					// Prevent endless concatenation if file is edited with PDFsharp more than once.
-					if (!producer.StartsWith(VersionInfo.Title))
-						producer = pdfSharpProducer;
-				}
-				info.Elements.SetString(PdfDocumentInformation.Keys.Producer, producer);
-			}
+            // Keep original producer if file was imported.
+            if (_openMode == PdfDocumentOpenMode.Modify)
+            {
+                string producer = info.Producer;
+                if (producer.Length == 0)
+                    producer = pdfSharpProducer;
+                else
+                {
+                    // Prevent endless concatenation if file is edited with PDFsharp more than once.
+                    if (!producer.StartsWith(VersionInfo.Title))
+                        producer = pdfSharpProducer;
+                }
+                info.Elements.SetString(PdfDocumentInformation.Keys.Producer, producer);
+            }
 
-			// Prepare used fonts.
-			if (_fontTable != null)
-				_fontTable.PrepareForSave();
+            // Prepare used fonts.
+            if (_fontTable != null)
+                _fontTable.PrepareForSave();
 
-			// Let catalog do the rest.
-			Catalog.PrepareForSave();
+            // Let catalog do the rest.
+            Catalog.PrepareForSave();
 
 #if true
-			if ((_openMode == PdfDocumentOpenMode.Modify || _trailers.Count == 1) && !_trailers.Any(t => t.IsReadOnly))
-			{
-				// Remove all unreachable objects (e.g. from deleted pages)
-				int removed = _irefTable.Compact();
-				if (removed != 0)
-					Debug.WriteLine("PrepareForSave: Number of deleted unreachable objects: " + removed);
-				_irefTable.Renumber();
-			}
+            if ((_openMode == PdfDocumentOpenMode.Modify || _trailers.Count == 1) && !_trailers.Any(t => t.IsReadOnly))
+            {
+                // Remove all unreachable objects (e.g. from deleted pages)
+                int removed = _irefTable.Compact();
+                if (removed != 0)
+                    Debug.WriteLine("PrepareForSave: Number of deleted unreachable objects: " + removed);
+                _irefTable.Renumber();
+            }
 #endif
-		}
+        }
 
-		/// <summary>
-		/// Determines whether the document can be saved.
-		/// </summary>
-		public bool CanSave(ref string message)
-		{
-			if (!SecuritySettings.CanSave(ref message))
-				return false;
+        /// <summary>
+        /// Determines whether the document can be saved.
+        /// </summary>
+        public bool CanSave(ref string message)
+        {
+            if (!SecuritySettings.CanSave(ref message))
+                return false;
 
-			return true;
-		}
+            return true;
+        }
 
-		internal bool HasVersion(string version)
-		{
-			return String.Compare(Catalog.Version, version) >= 0;
-		}
+        internal bool HasVersion(string version)
+        {
+            return String.Compare(Catalog.Version, version) >= 0;
+        }
 
-		/// <summary>
-		/// Gets the document options used for saving the document.
-		/// </summary>
-		public PdfDocumentOptions Options
-		{
-			get
-			{
-				if (_options == null)
-					_options = new PdfDocumentOptions(this);
-				return _options;
-			}
-		}
-		PdfDocumentOptions _options;
+        /// <summary>
+        /// Gets the document options used for saving the document.
+        /// </summary>
+        public PdfDocumentOptions Options
+        {
+            get
+            {
+                if (_options == null)
+                    _options = new PdfDocumentOptions(this);
+                return _options;
+            }
+        }
+        PdfDocumentOptions _options;
 
-		/// <summary>
-		/// Gets PDF specific document settings.
-		/// </summary>
-		public PdfDocumentSettings Settings
-		{
-			get
-			{
-				if (_settings == null)
-					_settings = new PdfDocumentSettings(this);
-				return _settings;
-			}
-		}
-		PdfDocumentSettings _settings;
+        /// <summary>
+        /// Gets PDF specific document settings.
+        /// </summary>
+        public PdfDocumentSettings Settings
+        {
+            get
+            {
+                if (_settings == null)
+                    _settings = new PdfDocumentSettings(this);
+                return _settings;
+            }
+        }
+        PdfDocumentSettings _settings;
 
-		/// <summary>
-		/// NYI Indicates whether large objects are written immediately to the output stream to relieve
-		/// memory consumption.
-		/// </summary>
-		internal bool EarlyWrite
-		{
-			get { return false; }
-		}
+        /// <summary>
+        /// NYI Indicates whether large objects are written immediately to the output stream to relieve
+        /// memory consumption.
+        /// </summary>
+        internal bool EarlyWrite
+        {
+            get { return false; }
+        }
 
-		/// <summary>
-		/// Gets or sets the PDF version number. Return value 14 e.g. means PDF 1.4 / Acrobat 5 etc.
-		/// </summary>
-		public int Version
-		{
-			get { return _version; }
-			set
-			{
-				if (!CanModify)
-					throw new InvalidOperationException(PSSR.CannotModify);
-				if (value < 12 || value > 17) // TODO not really implemented
-					throw new ArgumentException(PSSR.InvalidVersionNumber, "value");
-				_version = value;
-			}
-		}
-		internal int _version;
+        /// <summary>
+        /// Gets or sets the PDF version number. Return value 14 e.g. means PDF 1.4 / Acrobat 5 etc.
+        /// </summary>
+        public int Version
+        {
+            get { return _version; }
+            set
+            {
+                if (!CanModify)
+                    throw new InvalidOperationException(PSSR.CannotModify);
+                if (value < 12 || value > 17) // TODO not really implemented
+                    throw new ArgumentException(PSSR.InvalidVersionNumber, "value");
+                _version = value;
+            }
+        }
+        internal int _version;
 
-		/// <summary>
-		/// Gets the number of pages in the document.
-		/// </summary>
-		public int PageCount
-		{
-			get
-			{
-				if (CanModify)
-					return Pages.Count;
-				// PdfOpenMode is InformationOnly
-				PdfDictionary pageTreeRoot = (PdfDictionary)Catalog.Elements.GetObject(PdfCatalog.Keys.Pages);
-				return pageTreeRoot.Elements.GetInteger(PdfPages.Keys.Count);
-			}
-		}
+        /// <summary>
+        /// Gets the number of pages in the document.
+        /// </summary>
+        public int PageCount
+        {
+            get
+            {
+                if (CanModify)
+                    return Pages.Count;
+                // PdfOpenMode is InformationOnly
+                PdfDictionary pageTreeRoot = (PdfDictionary)Catalog.Elements.GetObject(PdfCatalog.Keys.Pages);
+                return pageTreeRoot.Elements.GetInteger(PdfPages.Keys.Count);
+            }
+        }
 
-		/// <summary>
-		/// Gets the file size of the document.
-		/// </summary>
-		public long FileSize
-		{
-			get { return _fileSize; }
-		}
-		internal long _fileSize; // TODO: make private
+        /// <summary>
+        /// Gets the file size of the document.
+        /// </summary>
+        public long FileSize
+        {
+            get { return _fileSize; }
+        }
+        internal long _fileSize; // TODO: make private
 
-		/// <summary>
-		/// Gets the full qualified file name if the document was read form a file, or an empty string otherwise.
-		/// </summary>
-		public string FullPath
-		{
-			get { return _fullPath; }
-		}
-		internal string _fullPath = String.Empty; // TODO: make private
+        /// <summary>
+        /// Gets the full qualified file name if the document was read form a file, or an empty string otherwise.
+        /// </summary>
+        public string FullPath
+        {
+            get { return _fullPath; }
+        }
+        internal string _fullPath = String.Empty; // TODO: make private
 
-		/// <summary>
-		/// Gets a Guid that uniquely identifies this instance of PdfDocument.
-		/// </summary>
-		public Guid Guid
-		{
-			get { return _guid; }
-		}
-		Guid _guid = Guid.NewGuid();
+        /// <summary>
+        /// Gets a Guid that uniquely identifies this instance of PdfDocument.
+        /// </summary>
+        public Guid Guid
+        {
+            get { return _guid; }
+        }
+        Guid _guid = Guid.NewGuid();
 
-		internal DocumentHandle Handle
-		{
-			get
-			{
-				if (_handle == null)
-					_handle = new DocumentHandle(this);
-				return _handle;
-			}
-		}
-		DocumentHandle _handle;
+        internal DocumentHandle Handle
+        {
+            get
+            {
+                if (_handle == null)
+                    _handle = new DocumentHandle(this);
+                return _handle;
+            }
+        }
+        DocumentHandle _handle;
 
-		/// <summary>
-		/// Returns a value indicating whether the document was newly created or opened from an existing document.
-		/// Returns true if the document was opened with the PdfReader.Open function, false otherwise.
-		/// </summary>
-		public bool IsImported
-		{
-			get { return (_state & DocumentState.Imported) != 0; }
-		}
+        /// <summary>
+        /// Returns a value indicating whether the document was newly created or opened from an existing document.
+        /// Returns true if the document was opened with the PdfReader.Open function, false otherwise.
+        /// </summary>
+        public bool IsImported
+        {
+            get { return (_state & DocumentState.Imported) != 0; }
+        }
 
-		/// <summary>
-		/// Returns a value indicating whether the document is read only or can be modified.
-		/// </summary>
-		public bool IsReadOnly
-		{
-			get { return (_openMode != PdfDocumentOpenMode.Modify); }
-		}
+        /// <summary>
+        /// Returns a value indicating whether the document is read only or can be modified.
+        /// </summary>
+        public bool IsReadOnly
+        {
+            get { return (_openMode != PdfDocumentOpenMode.Modify); }
+        }
 
-		internal Exception DocumentNotImported()
-		{
-			return new InvalidOperationException("Document not imported.");
-		}
+        internal Exception DocumentNotImported()
+        {
+            return new InvalidOperationException("Document not imported.");
+        }
 
-		/// <summary>
-		/// Gets information about the document.
-		/// </summary>
-		public PdfDocumentInformation Info
-		{
-			get
-			{
-				if (_info == null)
-					_info = _trailer.Info;
-				return _info;
-			}
-		}
-		PdfDocumentInformation _info;  // never changes if once created
+        /// <summary>
+        /// Gets information about the document.
+        /// </summary>
+        public PdfDocumentInformation Info
+        {
+            get
+            {
+                if (_info == null)
+                    _info = _trailer.Info;
+                return _info;
+            }
+        }
+        PdfDocumentInformation _info;  // never changes if once created
 
-		/// <summary>
-		/// This function is intended to be undocumented.
-		/// </summary>
-		public PdfCustomValues CustomValues
-		{
-			get
-			{
-				if (_customValues == null)
-					_customValues = PdfCustomValues.Get(Catalog.Elements);
-				return _customValues;
-			}
-			set
-			{
-				if (value != null)
-					throw new ArgumentException("Only null is allowed to clear all custom values.");
-				PdfCustomValues.Remove(Catalog.Elements);
-				_customValues = null;
-			}
-		}
-		PdfCustomValues _customValues;
+        /// <summary>
+        /// This function is intended to be undocumented.
+        /// </summary>
+        public PdfCustomValues CustomValues
+        {
+            get
+            {
+                if (_customValues == null)
+                    _customValues = PdfCustomValues.Get(Catalog.Elements);
+                return _customValues;
+            }
+            set
+            {
+                if (value != null)
+                    throw new ArgumentException("Only null is allowed to clear all custom values.");
+                PdfCustomValues.Remove(Catalog.Elements);
+                _customValues = null;
+            }
+        }
+        PdfCustomValues _customValues;
 
-		/// <summary>
-		/// Get the pages dictionary.
-		/// </summary>
-		public PdfPages Pages
-		{
-			get
-			{
-				if (_pages == null)
-				{
-					UnderConstruction = true;
-					try
-					{
-						_pages = Catalog.Pages;
-					}
-					finally
-					{
-						UnderConstruction = false;
-					}
-				}
-				return _pages;
-			}
-		}
-		PdfPages _pages;  // never changes if once created
+        /// <summary>
+        /// Get the pages dictionary.
+        /// </summary>
+        public PdfPages Pages
+        {
+            get
+            {
+                if (_pages == null)
+                {
+                    UnderConstruction = true;
+                    try
+                    {
+                        _pages = Catalog.Pages;
+                    }
+                    finally
+                    {
+                        UnderConstruction = false;
+                    }
+                }
+                return _pages;
+            }
+        }
+        PdfPages _pages;  // never changes if once created
 
-		/// <summary>
-		/// Gets or sets a value specifying the page layout to be used when the document is opened.
-		/// </summary>
-		public PdfPageLayout PageLayout
-		{
-			get { return Catalog.PageLayout; }
-			set
-			{
-				if (!CanModify)
-					throw new InvalidOperationException(PSSR.CannotModify);
-				Catalog.PageLayout = value;
-			}
-		}
+        /// <summary>
+        /// Gets or sets a value specifying the page layout to be used when the document is opened.
+        /// </summary>
+        public PdfPageLayout PageLayout
+        {
+            get { return Catalog.PageLayout; }
+            set
+            {
+                if (!CanModify)
+                    throw new InvalidOperationException(PSSR.CannotModify);
+                Catalog.PageLayout = value;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets a value specifying how the document should be displayed when opened.
-		/// </summary>
-		public PdfPageMode PageMode
-		{
-			get { return Catalog.PageMode; }
-			set
-			{
-				if (!CanModify)
-					throw new InvalidOperationException(PSSR.CannotModify);
-				Catalog.PageMode = value;
-			}
-		}
+        /// <summary>
+        /// Gets or sets a value specifying how the document should be displayed when opened.
+        /// </summary>
+        public PdfPageMode PageMode
+        {
+            get { return Catalog.PageMode; }
+            set
+            {
+                if (!CanModify)
+                    throw new InvalidOperationException(PSSR.CannotModify);
+                Catalog.PageMode = value;
+            }
+        }
 
-		/// <summary>
-		/// Gets the viewer preferences of this document.
-		/// </summary>
-		public PdfViewerPreferences ViewerPreferences
-		{
-			get { return Catalog.ViewerPreferences; }
-		}
+        /// <summary>
+        /// Gets the viewer preferences of this document.
+        /// </summary>
+        public PdfViewerPreferences ViewerPreferences
+        {
+            get { return Catalog.ViewerPreferences; }
+        }
 
-		/// <summary>
-		/// Gets the root of the outline (or bookmark) tree.
-		/// </summary>
-		public PdfOutlineCollection Outlines
-		{
-			get { return Catalog.Outlines; }
-		}
+        /// <summary>
+        /// Gets the root of the outline (or bookmark) tree.
+        /// </summary>
+        public PdfOutlineCollection Outlines
+        {
+            get { return Catalog.Outlines; }
+        }
 
-		internal bool UnderConstruction { get; set; }
+        internal bool UnderConstruction { get; set; }
 
-		/// <summary>
-		/// Get the AcroForm dictionary.
-		/// </summary>
-		public PdfAcroForm AcroForm
-		{
-			get { return Catalog.AcroForm; }
-		}
+        /// <summary>
+        /// Get the AcroForm dictionary.
+        /// </summary>
+        public PdfAcroForm AcroForm
+        {
+            get { return Catalog.AcroForm; }
+        }
 
-		/// <summary>
-		/// Gets or sets the default language of the document.
-		/// </summary>
-		public string Language
-		{
-			get { return Catalog.Language; }
-			set { Catalog.Language = value; }
-			//get { return Catalog.Elements.GetString(PdfCatalog.Keys.Lang); }
-			//set { Catalog.Elements.SetString(PdfCatalog.Keys.Lang, value); }
-		}
+        /// <summary>
+        /// Gets or sets the default language of the document.
+        /// </summary>
+        public string Language
+        {
+            get { return Catalog.Language; }
+            set { Catalog.Language = value; }
+            //get { return Catalog.Elements.GetString(PdfCatalog.Keys.Lang); }
+            //set { Catalog.Elements.SetString(PdfCatalog.Keys.Lang, value); }
+        }
 
-		/// <summary>
-		/// Gets the security settings of this document.
-		/// </summary>
-		public PdfSecuritySettings SecuritySettings
-		{
-			get { return _securitySettings ?? (_securitySettings = new PdfSecuritySettings(this)); }
-		}
-		internal PdfSecuritySettings _securitySettings;
+        /// <summary>
+        /// Gets the security settings of this document.
+        /// </summary>
+        public PdfSecuritySettings SecuritySettings
+        {
+            get { return _securitySettings ?? (_securitySettings = new PdfSecuritySettings(this)); }
+        }
+        internal PdfSecuritySettings _securitySettings;
 
-		/// <summary>
-		/// Gets the document font table that holds all fonts used in the current document.
-		/// </summary>
-		internal PdfFontTable FontTable
-		{
-			get { return _fontTable ?? (_fontTable = new PdfFontTable(this)); }
-		}
-		PdfFontTable _fontTable;
+        /// <summary>
+        /// Gets the document font table that holds all fonts used in the current document.
+        /// </summary>
+        internal PdfFontTable FontTable
+        {
+            get { return _fontTable ?? (_fontTable = new PdfFontTable(this)); }
+        }
+        PdfFontTable _fontTable;
 
-		/// <summary>
-		/// Gets the document image table that holds all images used in the current document.
-		/// </summary>
-		internal PdfImageTable ImageTable
-		{
-			get
-			{
-				if (_imageTable == null)
-					_imageTable = new PdfImageTable(this);
-				return _imageTable;
-			}
-		}
-		PdfImageTable _imageTable;
+        /// <summary>
+        /// Gets the document image table that holds all images used in the current document.
+        /// </summary>
+        internal PdfImageTable ImageTable
+        {
+            get
+            {
+                if (_imageTable == null)
+                    _imageTable = new PdfImageTable(this);
+                return _imageTable;
+            }
+        }
+        PdfImageTable _imageTable;
 
-		/// <summary>
-		/// Gets the document form table that holds all form external objects used in the current document.
-		/// </summary>
-		internal PdfFormXObjectTable FormTable  // TODO: Rename to ExternalDocumentTable.
-		{
-			get { return _formTable ?? (_formTable = new PdfFormXObjectTable(this)); }
-		}
-		PdfFormXObjectTable _formTable;
+        /// <summary>
+        /// Gets the document form table that holds all form external objects used in the current document.
+        /// </summary>
+        internal PdfFormXObjectTable FormTable  // TODO: Rename to ExternalDocumentTable.
+        {
+            get { return _formTable ?? (_formTable = new PdfFormXObjectTable(this)); }
+        }
+        PdfFormXObjectTable _formTable;
 
-		/// <summary>
-		/// Gets the document ExtGState table that holds all form state objects used in the current document.
-		/// </summary>
-		internal PdfExtGStateTable ExtGStateTable
-		{
-			get { return _extGStateTable ?? (_extGStateTable = new PdfExtGStateTable(this)); }
-		}
-		PdfExtGStateTable _extGStateTable;
+        /// <summary>
+        /// Gets the document ExtGState table that holds all form state objects used in the current document.
+        /// </summary>
+        internal PdfExtGStateTable ExtGStateTable
+        {
+            get { return _extGStateTable ?? (_extGStateTable = new PdfExtGStateTable(this)); }
+        }
+        PdfExtGStateTable _extGStateTable;
 
-		/// <summary>
-		/// Gets the PdfCatalog of the current document.
-		/// </summary>
-		internal PdfCatalog Catalog
-		{
-			get { return _catalog ?? (_catalog = _trailer.Root); }
-		}
-		PdfCatalog _catalog;  // never changes if once created
+        /// <summary>
+        /// Gets the PdfCatalog of the current document.
+        /// </summary>
+        internal PdfCatalog Catalog
+        {
+            get { return _catalog ?? (_catalog = _trailer.Root); }
+        }
+        PdfCatalog _catalog;  // never changes if once created
 
-		/// <summary>
-		/// Gets the PdfInternals object of this document, that grants access to some internal structures
-		/// which are not part of the public interface of PdfDocument.
-		/// </summary>
-		public new PdfInternals Internals
-		{
-			get { return _internals ?? (_internals = new PdfInternals(this)); }
-		}
-		PdfInternals _internals;
+        /// <summary>
+        /// Gets the PdfInternals object of this document, that grants access to some internal structures
+        /// which are not part of the public interface of PdfDocument.
+        /// </summary>
+        public new PdfInternals Internals
+        {
+            get { return _internals ?? (_internals = new PdfInternals(this)); }
+        }
+        PdfInternals _internals;
 
-		/// <summary>
-		/// Creates a new page and adds it to this document.
-		/// Depending of the IsMetric property of the current region the page size is set to 
-		/// A4 or Letter respectively. If this size is not appropriate it should be changed before
-		/// any drawing operations are performed on the page.
-		/// </summary>
-		public PdfPage AddPage()
-		{
-			if (!CanModify)
-				throw new InvalidOperationException(PSSR.CannotModify);
-			return Catalog.Pages.Add();
-		}
+        /// <summary>
+        /// Creates a new page and adds it to this document.
+        /// Depending of the IsMetric property of the current region the page size is set to 
+        /// A4 or Letter respectively. If this size is not appropriate it should be changed before
+        /// any drawing operations are performed on the page.
+        /// </summary>
+        public PdfPage AddPage()
+        {
+            if (!CanModify)
+                throw new InvalidOperationException(PSSR.CannotModify);
+            return Catalog.Pages.Add();
+        }
 
-		/// <summary>
-		/// Adds the specified page to this document. If the page is from an external document,
-		/// it is imported to this document. In this case the returned page is not the same
-		/// object as the specified one.
-		/// </summary>
-		public PdfPage AddPage(PdfPage page)
-		{
-			if (!CanModify)
-				throw new InvalidOperationException(PSSR.CannotModify);
-			return Catalog.Pages.Add(page);
-		}
+        /// <summary>
+        /// Adds the specified page to this document. If the page is from an external document,
+        /// it is imported to this document. In this case the returned page is not the same
+        /// object as the specified one.
+        /// </summary>
+        public PdfPage AddPage(PdfPage page)
+        {
+            if (!CanModify)
+                throw new InvalidOperationException(PSSR.CannotModify);
+            return Catalog.Pages.Add(page);
+        }
 
-		/// <summary>
-		/// Creates a new page and inserts it in this document at the specified position.
-		/// </summary>
-		public PdfPage InsertPage(int index)
-		{
-			if (!CanModify)
-				throw new InvalidOperationException(PSSR.CannotModify);
-			return Catalog.Pages.Insert(index);
-		}
+        /// <summary>
+        /// Creates a new page and inserts it in this document at the specified position.
+        /// </summary>
+        public PdfPage InsertPage(int index)
+        {
+            if (!CanModify)
+                throw new InvalidOperationException(PSSR.CannotModify);
+            return Catalog.Pages.Insert(index);
+        }
 
-		/// <summary>
-		/// Inserts the specified page in this document. If the page is from an external document,
-		/// it is imported to this document. In this case the returned page is not the same
-		/// object as the specified one.
-		/// </summary>
-		public PdfPage InsertPage(int index, PdfPage page)
-		{
-			if (!CanModify)
-				throw new InvalidOperationException(PSSR.CannotModify);
-			return Catalog.Pages.Insert(index, page);
-		}
+        /// <summary>
+        /// Inserts the specified page in this document. If the page is from an external document,
+        /// it is imported to this document. In this case the returned page is not the same
+        /// object as the specified one.
+        /// </summary>
+        public PdfPage InsertPage(int index, PdfPage page)
+        {
+            if (!CanModify)
+                throw new InvalidOperationException(PSSR.CannotModify);
+            return Catalog.Pages.Insert(index, page);
+        }
 
-		/// <summary>
-		/// Gets the security handler.
-		/// </summary>
-		public PdfStandardSecurityHandler SecurityHandler
-		{
-			get { return _trailer.SecurityHandler; }
-		}
+        /// <summary>
+        /// Gets the security handler.
+        /// </summary>
+        public PdfStandardSecurityHandler SecurityHandler
+        {
+            get { return _trailer.SecurityHandler; }
+        }
 
-		internal List<PdfTrailer> _trailers = new List<PdfTrailer>();
-		private IReadOnlyCollection<PdfTrailer> _trailersAsc;
+        internal List<PdfTrailer> _trailers = new List<PdfTrailer>();
+        private IReadOnlyCollection<PdfTrailer> _trailersAsc;
+        private IReadOnlyCollection<PdfTrailer> _trailersDesc;
 
-		internal PdfTrailer _trailer; //always the last one
-		internal PdfCrossReferenceTable _irefTable;
-		internal Stream _outStream;
+        internal PdfTrailer _trailer; //always the last one
+        internal PdfCrossReferenceTable _irefTable;
+        internal Stream _outStream;
 
-		// Imported Document
-		internal Lexer _lexer;
+        // Imported Document
+        internal Lexer _lexer;
 
-		internal DateTime _creation;
+        internal DateTime _creation;
 
-		internal IReadOnlyCollection<PdfTrailer> GetSortedTrailers()
-		{
-			if (_trailersAsc == null || _trailersAsc.Count != _trailers.Count)
-			{
-				_trailersAsc = _trailers.OrderBy(t => t.Info.ModificationDate.ToUniversalTime()).ToList().AsReadOnly();
-			}
+        internal IReadOnlyCollection<PdfTrailer> GetSortedTrailers(bool ascending = true)
+        {
+            if (ascending)
+            {
+                if (_trailersAsc == null || _trailersAsc.Count != _trailers.Count)
+                {
+                    _trailersAsc = _trailers.OrderBy(t => t.Info.ModificationDate.ToUniversalTime()).ToList().AsReadOnly();
+                }
 
-			return _trailersAsc;
-		}
+                return _trailersAsc;
+            }
 
-		/// <summary>
-		/// Occurs when the specified document is not used anymore for importing content.
-		/// </summary>
-		internal void OnExternalDocumentFinalized(PdfDocument.DocumentHandle handle)
-		{
-			if (tls != null)
-			{
-				//PdfDocument[] documents = tls.Documents;
-				tls.DetachDocument(handle);
-			}
+            if (_trailersDesc == null || _trailersDesc.Count != _trailers.Count)
+            {
+                _trailersDesc = _trailers.OrderByDescending(t => t.Info.ModificationDate.ToUniversalTime()).ToList().AsReadOnly();
+            }
 
-			if (_formTable != null)
-				_formTable.DetachDocument(handle);
-		}
+            return _trailersDesc;
+        }
 
-		//internal static GlobalObjectTable Gob = new GlobalObjectTable();
+        /// <summary>
+        /// Occurs when the specified document is not used anymore for importing content.
+        /// </summary>
+        internal void OnExternalDocumentFinalized(PdfDocument.DocumentHandle handle)
+        {
+            if (tls != null)
+            {
+                //PdfDocument[] documents = tls.Documents;
+                tls.DetachDocument(handle);
+            }
 
-		/// <summary>
-		/// Gets the ThreadLocalStorage object. It is used for caching objects that should created
-		/// only once.
-		/// </summary>
-		internal static ThreadLocalStorage Tls
-		{
-			get { return tls ?? (tls = new ThreadLocalStorage()); }
-		}
-		[ThreadStatic]
-		static ThreadLocalStorage tls;
+            if (_formTable != null)
+                _formTable.DetachDocument(handle);
+        }
 
-		[DebuggerDisplay("(ID={ID}, alive={IsAlive})")]
-		internal class DocumentHandle
-		{
-			public DocumentHandle(PdfDocument document)
-			{
-				_weakRef = new WeakReference(document);
-				ID = document._guid.ToString("B").ToUpper();
-			}
+        //internal static GlobalObjectTable Gob = new GlobalObjectTable();
 
-			public bool IsAlive
-			{
-				get { return _weakRef.IsAlive; }
-			}
+        /// <summary>
+        /// Gets the ThreadLocalStorage object. It is used for caching objects that should created
+        /// only once.
+        /// </summary>
+        internal static ThreadLocalStorage Tls
+        {
+            get { return tls ?? (tls = new ThreadLocalStorage()); }
+        }
+        [ThreadStatic]
+        static ThreadLocalStorage tls;
 
-			public PdfDocument Target
-			{
-				get { return _weakRef.Target as PdfDocument; }
-			}
-			readonly WeakReference _weakRef;
+        [DebuggerDisplay("(ID={ID}, alive={IsAlive})")]
+        internal class DocumentHandle
+        {
+            public DocumentHandle(PdfDocument document)
+            {
+                _weakRef = new WeakReference(document);
+                ID = document._guid.ToString("B").ToUpper();
+            }
 
-			public string ID;
+            public bool IsAlive
+            {
+                get { return _weakRef.IsAlive; }
+            }
 
-			public override bool Equals(object obj)
-			{
-				DocumentHandle handle = obj as DocumentHandle;
-				if (!ReferenceEquals(handle, null))
-					return ID == handle.ID;
-				return false;
-			}
+            public PdfDocument Target
+            {
+                get { return _weakRef.Target as PdfDocument; }
+            }
+            readonly WeakReference _weakRef;
 
-			public override int GetHashCode()
-			{
-				return ID.GetHashCode();
-			}
+            public string ID;
 
-			public static bool operator ==(DocumentHandle left, DocumentHandle right)
-			{
-				if (ReferenceEquals(left, null))
-					return ReferenceEquals(right, null);
-				return left.Equals(right);
-			}
+            public override bool Equals(object obj)
+            {
+                DocumentHandle handle = obj as DocumentHandle;
+                if (!ReferenceEquals(handle, null))
+                    return ID == handle.ID;
+                return false;
+            }
 
-			public static bool operator !=(DocumentHandle left, DocumentHandle right)
-			{
-				return !(left == right);
-			}
-		}
+            public override int GetHashCode()
+            {
+                return ID.GetHashCode();
+            }
+
+            public static bool operator ==(DocumentHandle left, DocumentHandle right)
+            {
+                if (ReferenceEquals(left, null))
+                    return ReferenceEquals(right, null);
+                return left.Equals(right);
+            }
+
+            public static bool operator !=(DocumentHandle left, DocumentHandle right)
+            {
+                return !(left == right);
+            }
+        }
 
 
-		public override int GetHashCode()
-		{
-			return Guid.GetHashCode();
-		}
-	}
+        public override int GetHashCode()
+        {
+            return Guid.GetHashCode();
+        }
+    }
 }

--- a/src/PdfSharper/Pdf/PdfDocumentInformation.cs
+++ b/src/PdfSharper/Pdf/PdfDocumentInformation.cs
@@ -120,6 +120,11 @@ namespace PdfSharper.Pdf
             set { Elements.SetDateTime(Keys.ModDate, value); }
         }
 
+        public override void FlagAsDirty()
+        {
+            //we have already cloned this, no need to flag as dirty
+        }
+
         // TODO CustomProperties and meta data
 
         /// <summary>


### PR DESCRIPTION
Grayscale conversion needs rounding when going to double to ensure accuracy
If parent field reference is already an acrofield use that
Adding a child field needs to flag as dirty for incremental updates
Default Appearance streams need to use ContentFontName
When specific field type is created, remap references to it
Adding a field needs to mark annotations array as dirty
Only set needs appearances when field is dirty
A new form stream is always created in render appearance, just use it.
Trailer document arrays are always compact
Type0fonts need to read and write as arrays, not string literals
Annotations set a modified when dirty and not a widget annotation
TextField values must be newlined on 256 characters
Parser read date strings as dates
Support compact arrays
Date parsing always uses local time and offsets
Remove direct element setting in dictionary so that isdirty is updated