### PR TITLE
Feature/render match adobe streams

### DIFF
--- a/src/PDFsharper.UnitTests/PdfTextFieldTests.cs
+++ b/src/PDFsharper.UnitTests/PdfTextFieldTests.cs
@@ -56,8 +56,9 @@ namespace PDFsharper.UnitTests
 
             tf.PrepareForSave();
 
-            Assert.IsTrue(tf.Elements.ContainsKey(PdfAnnotation.Keys.AP), "Empty Text Field should have an appearance stream, used for background colors.");
+            Assert.IsFalse(tf.Elements.ContainsKey(PdfAnnotation.Keys.AP), "Empty Text Field should not have an appearance stream");
         }
+
         private static void SetupAcroFormForDocument(PdfDocument testDoc)
         {
             testDoc.Catalog.AcroForm = new PdfAcroForm(testDoc);

--- a/src/PdfSharper/Drawing.Pdf/PdfGraphicsState.cs
+++ b/src/PdfSharper/Drawing.Pdf/PdfGraphicsState.cs
@@ -316,14 +316,15 @@ namespace PdfSharper.Drawing.Pdf
 
             if (_renderer.Owner.Version >= 14 && color.ColorSpace != XColorSpace.GrayScale && (_realizedFillColor.A != color.A || _realizedNonStrokeOverPrint != overPrint))
             {
-
-                PdfExtGState extGState = _renderer.Owner.ExtGStateTable.GetExtGStateNonStroke(color.A, overPrint);
-                string gs = _renderer.Resources.AddExtGState(extGState);
-                _renderer.AppendFormatString("{0} gs\n", gs);
-
                 // Must create transparency group.
                 if (_renderer._page != null && color.A < 1)
+                {
+                    PdfExtGState extGState = _renderer.Owner.ExtGStateTable.GetExtGStateNonStroke(color.A, overPrint);
+                    string gs = _renderer.Resources.AddExtGState(extGState);
+                    _renderer.AppendFormatString("{0} gs\n", gs);
+
                     _renderer._page.TransparencyUsed = true;
+                }
             }
             _realizedFillColor = color;
             _realizedNonStrokeOverPrint = overPrint;

--- a/src/PdfSharper/Drawing.Pdf/XGraphicsPdfRenderer.cs
+++ b/src/PdfSharper/Drawing.Pdf/XGraphicsPdfRenderer.cs
@@ -1771,6 +1771,7 @@ namespace PdfSharper.Drawing.Pdf
             if (_streamMode == StreamMode.Text)
             {
                 _content.Append("ET\n");
+                _content.Append("EMC\n");
                 _streamMode = StreamMode.Graphic;
             }
 
@@ -1786,7 +1787,10 @@ namespace PdfSharper.Drawing.Pdf
             if (_streamMode != StreamMode.Graphic)
             {
                 if (_streamMode == StreamMode.Text)
+                {
                     _content.Append("ET\n");
+                    _content.Append("EMC\n");
+                }
 
                 _streamMode = StreamMode.Graphic;
             }
@@ -1800,6 +1804,7 @@ namespace PdfSharper.Drawing.Pdf
             if (_streamMode != StreamMode.Text)
             {
                 _streamMode = StreamMode.Text;
+                _content.Append("/Tx BMC\n");
                 _content.Append("BT\n");
                 // Text matrix is empty after BT
                 _gfxState.RealizedTextPosition = new XPoint();
@@ -2082,12 +2087,15 @@ namespace PdfSharper.Drawing.Pdf
         /// </summary>
         void SaveState()
         {
-            Debug.Assert(_streamMode == StreamMode.Graphic, "Cannot save state in text mode.");
+            if (_content.Length > 0)
+            {
+                Debug.Assert(_streamMode == StreamMode.Graphic, "Cannot save state in text mode.");
 
-            _gfxStateStack.Push(_gfxState);
-            _gfxState = _gfxState.Clone();
-            _gfxState.Level = _gfxStateStack.Count;
-            Append("q\n");
+                _gfxStateStack.Push(_gfxState);
+                _gfxState = _gfxState.Clone();
+                _gfxState.Level = _gfxStateStack.Count;
+                Append("q\n");
+            }
         }
 
         /// <summary>

--- a/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
@@ -426,10 +426,14 @@ namespace PdfSharper.Pdf.AcroForms
                 xobj.CreateStream(new byte[] { });
 
             string s = xobj.Stream.ToString();
-            // Thank you Adobe: Without putting the content in 'EMC brackets'
-            // the text is not rendered by PDF Reader 9 or higher.
-            s = "/Tx BMC\n" + s + "\nEMC";
-            ap.Elements.GetDictionary("/N").Stream.Value = new RawEncoding().GetBytes(s);
+            if (!string.IsNullOrEmpty(s))
+            {
+                ap.Elements.GetDictionary("/N").Stream.Value = new RawEncoding().GetBytes(s);
+            }
+            else
+            {
+                Elements.Remove(PdfAnnotation.Keys.AP);
+            }
 #endif
         }
 


### PR DESCRIPTION
Gets rid of some invalid stream operators that adobe preflight was complaining about, moves the BMC , EMC code to be inside the stream rendering.