### PR TITLE
added font family names (to helvetica) for Arial and ArialMT 

### DIFF
--- a/src/PdfSharper/Fonts/AFM/AFMSource.cs
+++ b/src/PdfSharper/Fonts/AFM/AFMSource.cs
@@ -36,6 +36,8 @@ namespace PdfSharper.Fonts.AFM
             //Helvetica family
             { "Helvetica", new string[] { HELVETICA, HELVETICABOLD, HELVETICAOBLIQUE, HELVETICABOLDOBLIQUE} },
             { "Helv", new string[] { HELVETICA, HELVETICABOLD, HELVETICAOBLIQUE, HELVETICABOLDOBLIQUE} },
+            { "Arial", new string[] { HELVETICA, HELVETICABOLD, HELVETICAOBLIQUE, HELVETICABOLDOBLIQUE} },
+            { "ArialMT", new string[] { HELVETICA, HELVETICABOLD, HELVETICAOBLIQUE, HELVETICABOLDOBLIQUE} },
             
 
             //Times Roman Family


### PR DESCRIPTION
added Arial/ArialMT font family names to AFM source dictionary and associated to Helvetica metrics.