### PR TITLE
Removed Top/Bottom/Right margin for textfields when not Multiline

### DIFF
--- a/src/PDFsharper.UnitTests/Pdf.AcroForms/PdfTextFieldTests.cs
+++ b/src/PDFsharper.UnitTests/Pdf.AcroForms/PdfTextFieldTests.cs
@@ -373,10 +373,10 @@ namespace PDFsharper.UnitTests.Pdf.AcroForms
 
             field.SetDefaultMargins();
 
-            Assert.IsTrue(field.TopMargin == 2, "TopMargin should be 2");
-            Assert.IsTrue(field.BottomMargin == 2, "BottomMargin should be 2");
+            Assert.IsTrue(field.TopMargin == 0, "TopMargin should be 0");
+            Assert.IsTrue(field.BottomMargin == 0, "BottomMargin should be 0");
             Assert.IsTrue(field.LeftMargin == 2, "LeftMargin should be 2");
-            Assert.IsTrue(field.RightMargin == 2, "RightMargin should be 2");
+            Assert.IsTrue(field.RightMargin == 0, "RightMargin should be 0");
 
         }
 

--- a/src/PDFsharper.UnitTests/Pdf.AcroForms/PdfTextFieldTests.cs
+++ b/src/PDFsharper.UnitTests/Pdf.AcroForms/PdfTextFieldTests.cs
@@ -343,14 +343,11 @@ namespace PDFsharper.UnitTests.Pdf.AcroForms
             Assert.IsTrue(field.RightMargin == 0, "RightMargin should be 0");
 
             field.MultiLine = true;
-
-            field.SetDefaultMargins();
-
+            
             Assert.IsTrue(field.TopMargin == 4, "TopMargin should be 4");
             Assert.IsTrue(field.BottomMargin == 4, "BottomMargin should be 4");
             Assert.IsTrue(field.LeftMargin == 2, "LeftMargin should be 2");
             Assert.IsTrue(field.RightMargin == 2, "RightMargin should be 2");
-
         }
 
         [TestMethod]
@@ -370,14 +367,11 @@ namespace PDFsharper.UnitTests.Pdf.AcroForms
             Assert.IsTrue(field.RightMargin == 0, "RightMargin should be 0");
 
             field.MultiLine = false;
-
-            field.SetDefaultMargins();
-
+            
             Assert.IsTrue(field.TopMargin == 0, "TopMargin should be 0");
             Assert.IsTrue(field.BottomMargin == 0, "BottomMargin should be 0");
             Assert.IsTrue(field.LeftMargin == 2, "LeftMargin should be 2");
             Assert.IsTrue(field.RightMargin == 0, "RightMargin should be 0");
-
         }
 
         [TestMethod]

--- a/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
@@ -238,15 +238,16 @@ namespace PdfSharper.Pdf.AcroForms
             {
                 TopMargin = 4;
                 BottomMargin = 4;
+                RightMargin = 2;
             }
             else
             {
-                TopMargin = 2;
-                BottomMargin = 2;
+                TopMargin = 0;
+                BottomMargin = 0;
+                RightMargin = 0;
             }
 
             LeftMargin = 2;
-            RightMargin = 2;
         }
 
         /// <summary>

--- a/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
+++ b/src/PdfSharper/Pdf.AcroForms/PdfTextField.cs
@@ -195,6 +195,8 @@ namespace PdfSharper.Pdf.AcroForms
                     SetFlags |= PdfAcroFieldFlags.Multiline;
                 else
                     SetFlags &= ~PdfAcroFieldFlags.Multiline;
+
+                SetDefaultMargins();
             }
         }
 


### PR DESCRIPTION
Removed Top/Bottom/Right margin for textfields when not Multiline since text is vertically centered